### PR TITLE
Added Glyphs, Anchors and fixed code 

### DIFF
--- a/sources/NotoSansKhojki.glyphs
+++ b/sources/NotoSansKhojki.glyphs
@@ -1,5 +1,8 @@
 {
-.appVersion = "3180";
+.appVersion = "3151";
+DisplayStrings = (
+"/QA.alt/QU/kj_QA/QRA"
+);
 classes = (
 {
 code = "Anusvara Nukta Shadda u1123E I.alt I.alt2 I.alt3 I.alt4 Nukta.alt Anusvara.alt kj_vs_E.ns kj_vs_AI.ns E_Shadda.ns AI_Shadda.ns Nukta_Shadda.ns Nukta_E.ns Nukta_AI.ns Nukta_Shadda_E.ns Nukta_Shadda_AI.ns";
@@ -58,8 +61,10 @@ u1123C,
 u1123D,
 u1123E,
 KA.alt,
+QA.alt,
 II.alt,
 KU,
+QU,
 GHU,
 CU,
 II.alt2,
@@ -120,6 +125,7 @@ Nukta.alt,
 Anusvara.alt,
 kj_A,
 kj_AA,
+kj_Ishort,
 kj_I,
 kj_U,
 kj_E,
@@ -127,6 +133,7 @@ kj_AI,
 kj_O,
 kj_AU,
 kj_KA,
+kj_QA,
 kj_KHA,
 kj_GA,
 kj_GGA,
@@ -176,6 +183,7 @@ JJU,
 LLII,
 BHRA,
 KRA,
+QRA,
 MRA,
 SRA,
 THA.alt,
@@ -254,7 +262,7 @@ value = "Noto is a trademark of Google Inc.";
 },
 {
 name = versionString;
-value = "Version 2.004";
+value = "Version 2.003";
 },
 {
 name = Axes;
@@ -277,7 +285,7 @@ disablesNiceNames = 1;
 familyName = "Noto Sans Khojki";
 featurePrefixes = (
 {
-code = "lookup AltForms {\012    sub KSSA by KSSA.alt;\012    sub GNA by GNA.alt;\012    sub kj_KA by KA.alt;\012    sub kj_KHA by KHA.alt;\012    sub kj_THA by THA.alt;\012    sub kj_NA by NA.alt;\012    sub kj_PA by PA.alt;\012    sub kj_SA by SA.alt;\012    sub kj_HA by HA.alt;\012    sub kj_vs_I by I.alt;\012    sub kj_vs_II by II.alt;\012    sub kj_vs_U.ns by U.alt;\012} AltForms;\012\012lookup Alt2Forms {\012    sub YA.alt by YA.alt2;\012    sub kj_vs_I by I.alt2;\012    sub kj_vs_II by II.alt2;\012    sub kj_vs_U.ns by U.alt2;\012} Alt2Forms;\012\012lookup Alt3Forms {\012    sub YA.alt by YA.alt3;\012    sub kj_vs_I by I.alt3;\012    sub kj_vs_II by II.alt3;\012    sub kj_vs_U.ns by U.alt3;\012} Alt3Forms;\012\012lookup Alt4Forms {\012    sub kj_vs_I by I.alt4;\012    sub kj_vs_II by II.alt4;\012} Alt4Forms;\012\012lookup Alt5Forms {\012    sub kj_vs_II by II.alt5;\012} Alt5Forms;\012\012";
+code = "lookup AltForms {\012    sub KSSA by KSSA.alt;\012    sub GNA by GNA.alt;\012    sub kj_KA by KA.alt;\012    sub kj_QA by QA.alt;\012    sub kj_KHA by KHA.alt;\012    sub kj_THA by THA.alt;\012    sub kj_NA by NA.alt;\012    sub kj_PA by PA.alt;\012    sub kj_SA by SA.alt;\012    sub kj_HA by HA.alt;\012    sub kj_vs_I by I.alt;\012    sub kj_vs_II by II.alt;\012    sub kj_vs_U.ns by U.alt;\012} AltForms;\012\012lookup Alt2Forms {\012    sub YA.alt by YA.alt2;\012    sub kj_vs_I by I.alt2;\012    sub kj_vs_II by II.alt2;\012    sub kj_vs_U.ns by U.alt2;\012} Alt2Forms;\012\012lookup Alt3Forms {\012    sub YA.alt by YA.alt3;\012    sub kj_vs_I by I.alt3;\012    sub kj_vs_II by II.alt3;\012    sub kj_vs_U.ns by U.alt3;\012} Alt3Forms;\012\012lookup Alt4Forms {\012    sub kj_vs_I by I.alt4;\012    sub kj_vs_II by II.alt4;\012} Alt4Forms;\012\012lookup Alt5Forms {\012    sub kj_vs_II by II.alt5;\012} Alt5Forms;\012\012";
 name = "Alt Forms";
 },
 {
@@ -293,7 +301,7 @@ code = "lookup IncreaseSpaceBeforeAlt {\012    pos TRA 240;\012    pos DDDRA 40;
 name = "Space Before Alt";
 },
 {
-code = "languagesystem DFLT dflt;\012languagesystem khoj dflt;\012languagesystem gujr dflt;\012";
+code = "languagesystem khoj dflt;\012languagesystem gujr dflt;\012";
 name = Languagesystems;
 }
 );
@@ -303,15 +311,16 @@ code = "# Do this before vowel conjuncts\012lookup Akhand {\012    lookupflag Us
 name = akhn;
 },
 {
-code = "\012lookup VowelConjuncts {\012    lookupflag MarkAttachmentType @U;\012    sub uni200D virama kj_YA by YA.alt;\012    sub kj_KA uni200D virama kj_RA by KRA;\012    sub kj_KA kj_vs_U.ns by KU;\012    sub kj_KHA kj_vs_U.ns by KHU;\012    sub kj_GA virama kj_NA by GNA;\012    sub kj_GA virama kj_RA by kj_GGA;\012    sub kj_GA kj_vs_U.ns by GU;\012    sub kj_GHA kj_vs_U.ns by GHU;\012    sub kj_NGA kj_vs_U.ns by NGU;\012    sub kj_CA kj_vs_U.ns by CU;\012    sub kj_CHA kj_vs_U.ns by CHU;\012    sub kj_JA kj_vs_U.ns by JU;\012    sub kj_JJA kj_vs_U.ns by JJU;\012    sub kj_NYA kj_vs_U.ns by NYU;\012    sub kj_DDA kj_vs_U.ns by DDU;\012    sub kj_DDHA kj_vs_U.ns by DDHU;\012    sub kj_NNA kj_vs_U.ns by NNU;\012    sub kj_TA virama kj_RA kj_vs_U.ns by TRU;\012    sub kj_TA virama kj_RA by TRA;\012    sub kj_TA kj_vs_U.ns by TU;\012    sub kj_THA kj_vs_U.ns by THU;\012    sub kj_DA kj_vs_U.ns by DU;\012    sub kj_DDDA virama kj_RA kj_vs_U.ns by DDDRU;\012    sub kj_DDDA virama kj_RA by DDDRA;\012    sub kj_DDDA kj_vs_U.ns by DDDU;\012    sub kj_NA kj_vs_U.ns by NU;\012    sub kj_PA kj_vs_U.ns by PU;\012    sub kj_PHA kj_vs_U.ns by PHU;\012    sub kj_BA kj_vs_U.ns by BU;\012    sub kj_BBA kj_vs_U.ns by BBU;\012    sub kj_BHA uni200D virama kj_RA by BHRA;\012    sub kj_BHA kj_vs_U.ns by BHU;\012    sub kj_MA uni200D virama kj_RA by MRA;\012    sub kj_MA kj_vs_U.ns by MU;\012    sub kj_YA kj_vs_U.ns by YU;\012    sub kj_RA kj_vs_U.ns by RU;\012    sub kj_LA kj_vs_U.ns by LU;\012    sub kj_VA kj_vs_U.ns by VU;\012    sub kj_SA uni200D virama kj_RA by SRA;\012    sub kj_SA kj_vs_U.ns by SU;\012    sub kj_HA kj_vs_U.ns by HU;\012    sub kj_LLA kj_vs_U.ns by LLU;\012    sub virama kj_RA by RA.alt;\012    sub virama kj_YA by YA.alt;\012} VowelConjuncts;\012\012lookup RaU {\012    lookupflag MarkAttachmentType @U;\012    sub RA.alt kj_vs_U.ns by Ra_U;\012} RaU;\012\012lookup NuktaAndShaddaReordering {\012    lookupflag MarkAttachmentType @abovemarks;\012    sub [Nukta Nukta.alt]' lookup NuktaShaddaLigatures Shadda' [kj_vs_E.ns kj_vs_AI.ns]';\012    sub [Nukta Nukta.alt]' lookup MultipleSubstitution13 Shadda' kj_vs_O' lookup SingleSubstitution12;\012    sub [Nukta Nukta.alt]' lookup MultipleSubstitution14 Shadda' kj_vs_AU' lookup SingleSubstitution12;\012\012    sub [Nukta Nukta.alt]' lookup NuktaShaddaLigatures Shadda';\012\012    sub Nukta' lookup SwapNuktaShadda Shadda' lookup SwapNuktaShadda;\012    sub Nukta.alt' lookup SwapNuktaAltShadda Shadda' lookup SwapNuktaAltShadda;\012\012    sub [Nukta Nukta.alt]' lookup NuktaShaddaLigatures [kj_vs_E.ns kj_vs_AI.ns]';\012\012    sub Nukta' lookup SwapNuktaVsO kj_vs_O' lookup SwapNuktaVsO;\012    sub Nukta.alt' lookup SwapNuktaAltVsO kj_vs_O' lookup SwapNuktaAltVsO;\012\012    sub Nukta' lookup SwapNuktaVsAU kj_vs_AU' lookup SwapNuktaVsAU;\012    sub Nukta.alt' lookup SwapNuktaAltVsO kj_vs_AU' lookup SwapNuktaAltVsAU;\012\012    sub Shadda' lookup NuktaShaddaLigatures [kj_vs_E.ns kj_vs_AI.ns]';\012\012    sub Shadda' lookup SwapShaddaVsO kj_vs_O' lookup SwapShaddaVsO;\012    sub Shadda' lookup SwapShaddaVsAU kj_vs_AU' lookup SwapShaddaVsAU;\012} NuktaAndShaddaReordering;\012\012lookup IIConjuncts {\012    lookupflag IgnoreMarks;\012    sub DDDRA kj_vs_II by DDDRII;\012    sub kj_DDA kj_vs_II by DDII;\012    sub kj_DA kj_vs_I by DI;\012    sub kj_DA kj_vs_II by DII;\012    sub kj_DDDA kj_vs_II by DDDII;\012    sub kj_PHA kj_vs_I by PHI;\012    sub kj_PHA kj_vs_II by PHII;\012    sub kj_RA kj_vs_I by RI;\012    sub kj_RA kj_vs_II by RII;\012    sub kj_LLA kj_vs_II by LLII;\012} IIConjuncts;\012";
+code = "\012lookup VowelConjuncts {\012    lookupflag MarkAttachmentType @U;\012    sub uni200D virama kj_YA by YA.alt;\012    sub kj_KA virama kj_RA by KRA;\012    sub kj_QA virama kj_RA by QRA;\012    sub kj_KA kj_vs_U.ns by KU;\012    sub kj_QA kj_vs_U.ns by QU;\012    sub kj_KHA kj_vs_U.ns by KHU;\012    sub kj_GA virama kj_NA by GNA;\012    sub kj_GA virama kj_RA by kj_GGA;\012    sub kj_GA kj_vs_U.ns by GU;\012    sub kj_GHA kj_vs_U.ns by GHU;\012    sub kj_NGA kj_vs_U.ns by NGU;\012    sub kj_CA kj_vs_U.ns by CU;\012    sub kj_CHA kj_vs_U.ns by CHU;\012    sub kj_JA kj_vs_U.ns by JU;\012    sub kj_JJA kj_vs_U.ns by JJU;\012    sub kj_NYA kj_vs_U.ns by NYU;\012    sub kj_DDA kj_vs_U.ns by DDU;\012    sub kj_DDHA kj_vs_U.ns by DDHU;\012    sub kj_NNA kj_vs_U.ns by NNU;\012    sub kj_TA virama kj_RA kj_vs_U.ns by TRU;\012    sub kj_TA virama kj_RA by TRA;\012    sub kj_TA kj_vs_U.ns by TU;\012    sub kj_THA kj_vs_U.ns by THU;\012    sub kj_DA kj_vs_U.ns by DU;\012    sub kj_DDDA virama kj_RA kj_vs_U.ns by DDDRU;\012    sub kj_DDDA virama kj_RA by DDDRA;\012    sub kj_DDDA kj_vs_U.ns by DDDU;\012    sub kj_NA kj_vs_U.ns by NU;\012    sub kj_PA kj_vs_U.ns by PU;\012    sub kj_PHA kj_vs_U.ns by PHU;\012    sub kj_BA kj_vs_U.ns by BU;\012    sub kj_BBA kj_vs_U.ns by BBU;\012    sub kj_BHA virama kj_RA by BHRA;\012    sub kj_BHA kj_vs_U.ns by BHU;\012    sub kj_MA virama kj_RA by MRA;\012    sub kj_MA kj_vs_U.ns by MU;\012    sub kj_YA kj_vs_U.ns by YU;\012    sub kj_RA kj_vs_U.ns by RU;\012    sub kj_LA kj_vs_U.ns by LU;\012    sub kj_VA kj_vs_U.ns by VU;\012    sub kj_SA virama kj_RA by SRA;\012    sub kj_SA kj_vs_U.ns by SU;\012    sub kj_HA kj_vs_U.ns by HU;\012    sub kj_LLA kj_vs_U.ns by LLU;\012    sub virama kj_RA by RA.alt;\012    sub virama kj_YA by YA.alt;\012} VowelConjuncts;\012\012lookup RaU {\012    lookupflag MarkAttachmentType @U;\012    sub RA.alt kj_vs_U.ns by Ra_U;\012} RaU;\012\012lookup NuktaAndShaddaReordering {\012    lookupflag MarkAttachmentType @abovemarks;\012    sub [Nukta Nukta.alt]' lookup NuktaShaddaLigatures Shadda' [kj_vs_E.ns kj_vs_AI.ns]';\012    sub [Nukta Nukta.alt]' lookup MultipleSubstitution13 Shadda' kj_vs_O' lookup SingleSubstitution12;\012    sub [Nukta Nukta.alt]' lookup MultipleSubstitution14 Shadda' kj_vs_AU' lookup SingleSubstitution12;\012\012    sub [Nukta Nukta.alt]' lookup NuktaShaddaLigatures Shadda';\012\012    sub Nukta' lookup SwapNuktaShadda Shadda' lookup SwapNuktaShadda;\012    sub Nukta.alt' lookup SwapNuktaAltShadda Shadda' lookup SwapNuktaAltShadda;\012\012    sub [Nukta Nukta.alt]' lookup NuktaShaddaLigatures [kj_vs_E.ns kj_vs_AI.ns]';\012\012    sub Nukta' lookup SwapNuktaVsO kj_vs_O' lookup SwapNuktaVsO;\012    sub Nukta.alt' lookup SwapNuktaAltVsO kj_vs_O' lookup SwapNuktaAltVsO;\012\012    sub Nukta' lookup SwapNuktaVsAU kj_vs_AU' lookup SwapNuktaVsAU;\012    sub Nukta.alt' lookup SwapNuktaAltVsO kj_vs_AU' lookup SwapNuktaAltVsAU;\012\012    sub Shadda' lookup NuktaShaddaLigatures [kj_vs_E.ns kj_vs_AI.ns]';\012\012    sub Shadda' lookup SwapShaddaVsO kj_vs_O' lookup SwapShaddaVsO;\012    sub Shadda' lookup SwapShaddaVsAU kj_vs_AU' lookup SwapShaddaVsAU;\012} NuktaAndShaddaReordering;\012\012lookup IIConjuncts {\012    lookupflag IgnoreMarks;\012    sub DDDRA kj_vs_II by DDDRII;\012    sub kj_DDA kj_vs_II by DDII;\012    sub kj_DA kj_vs_I by DI;\012    sub kj_DA kj_vs_II by DII;\012    sub kj_DDDA kj_vs_II by DDDII;\012    sub kj_PHA kj_vs_I by PHI;\012    sub kj_PHA kj_vs_II by PHII;\012    sub kj_RA kj_vs_I by RI;\012    sub kj_RA kj_vs_II by RII;\012    sub kj_LLA kj_vs_II by LLII;\012} IIConjuncts;\012";
 name = ccmp;
+notes = "\012lookup VowelConjuncts {\012    lookupflag MarkAttachmentType @U;\012    sub uni200D virama kj_YA by YA.alt;\012    sub kj_KA uni200D virama kj_RA by KRA;\012    sub kj_QA uni200D virama kj_RA by QRA;\012    sub kj_KA kj_vs_U.ns by KU;\012    sub kj_KHA kj_vs_U.ns by KHU;\012    sub kj_GA virama kj_NA by GNA;\012    sub kj_GA virama kj_RA by kj_GGA;\012    sub kj_GA kj_vs_U.ns by GU;\012    sub kj_GHA kj_vs_U.ns by GHU;\012    sub kj_NGA kj_vs_U.ns by NGU;\012    sub kj_CA kj_vs_U.ns by CU;\012    sub kj_CHA kj_vs_U.ns by CHU;\012    sub kj_JA kj_vs_U.ns by JU;\012    sub kj_JJA kj_vs_U.ns by JJU;\012    sub kj_NYA kj_vs_U.ns by NYU;\012    sub kj_DDA kj_vs_U.ns by DDU;\012    sub kj_DDHA kj_vs_U.ns by DDHU;\012    sub kj_NNA kj_vs_U.ns by NNU;\012    sub kj_TA virama kj_RA kj_vs_U.ns by TRU;\012    sub kj_TA virama kj_RA by TRA;\012    sub kj_TA kj_vs_U.ns by TU;\012    sub kj_THA kj_vs_U.ns by THU;\012    sub kj_DA kj_vs_U.ns by DU;\012    sub kj_DDDA virama kj_RA kj_vs_U.ns by DDDRU;\012    sub kj_DDDA virama kj_RA by DDDRA;\012    sub kj_DDDA kj_vs_U.ns by DDDU;\012    sub kj_NA kj_vs_U.ns by NU;\012    sub kj_PA kj_vs_U.ns by PU;\012    sub kj_PHA kj_vs_U.ns by PHU;\012    sub kj_BA kj_vs_U.ns by BU;\012    sub kj_BBA kj_vs_U.ns by BBU;\012    sub kj_BHA uni200D virama kj_RA by BHRA;\012    sub kj_BHA kj_vs_U.ns by BHU;\012    sub kj_MA uni200D virama kj_RA by MRA;\012    sub kj_MA kj_vs_U.ns by MU;\012    sub kj_YA kj_vs_U.ns by YU;\012    sub kj_RA kj_vs_U.ns by RU;\012    sub kj_LA kj_vs_U.ns by LU;\012    sub kj_VA kj_vs_U.ns by VU;\012    sub kj_SA uni200D virama kj_RA by SRA;\012    sub kj_SA kj_vs_U.ns by SU;\012    sub kj_HA kj_vs_U.ns by HU;\012    sub kj_LLA kj_vs_U.ns by LLU;\012    sub virama kj_RA by RA.alt;\012    sub virama kj_YA by YA.alt;\012} VowelConjuncts;";
 },
 {
 code = "lookupflag MarkAttachmentType @U;\012sub [BHRA MRA kj_DHA kj_GGA kj_JJA kj_KHA] kj_vs_U.ns' by U.alt;\012sub [kj_TTA kj_TTHA] kj_vs_U.ns' by U.alt2;\012sub [KSSA GNA] kj_vs_U.ns' by U.alt3;\012sub kj_NA YA.alt' by YA.alt2;\012sub [kj_JA kj_TA kj_LA] YA.alt' by YA.alt3;\012sub [YA.alt YA.alt2] kj_vs_U.ns' by U.alt2;\012";
 name = blws;
 },
 {
-code = "lookupflag IgnoreMarks;\012sub @consonants' kj_vs_I' lookup AltForms;\012sub @consonants' kj_vs_II' lookup Alt2Forms;\012sub [YA.alt3 kj_CHA kj_DDA kj_DDHA kj_DHA kj_JJA kj_LLA kj_NNA]' kj_vs_I' lookup Alt2Forms;\012sub [YA.alt3 kj_CHA kj_DDA kj_DDHA kj_DHA kj_JJA kj_LLA kj_NNA]' kj_vs_II' lookup Alt2Forms;\012sub [kj_THA kj_PA kj_SA]' lookup AltForms kj_vs_I' lookup Alt3Forms;\012sub [kj_THA kj_PA kj_SA]' lookup AltForms kj_vs_II' lookup Alt5Forms;\012sub [kj_KHA kj_NA]' lookup AltForms kj_vs_I' lookup Alt4Forms;\012sub [kj_KHA kj_NA]' lookup AltForms kj_vs_II' lookup Alt4Forms;\012sub [DDDRA kj_TTA kj_TTHA kj_DDDA]' kj_vs_I' lookup Alt2Forms;\012sub [KSSA GNA kj_KA kj_HA]' lookup AltForms kj_vs_I';\012sub [KSSA GNA kj_KA kj_HA]' lookup AltForms kj_vs_II' lookup AltForms;\012sub [kj_NGA kj_NYA]' kj_vs_I' lookup Alt2Forms;\012sub [kj_NGA kj_NYA]' kj_vs_II' lookup Alt3Forms;\012";
+code = "lookupflag IgnoreMarks;\012sub @consonants' kj_vs_I' lookup AltForms;\012sub @consonants' kj_vs_II' lookup Alt2Forms;\012sub [YA.alt3 kj_CHA kj_DDA kj_DDHA kj_DHA kj_JJA kj_LLA kj_NNA]' kj_vs_I' lookup Alt2Forms;\012sub [YA.alt3 kj_CHA kj_DDA kj_DDHA kj_DHA kj_JJA kj_LLA kj_NNA]' kj_vs_II' lookup Alt2Forms;\012sub [kj_THA kj_PA kj_SA]' lookup AltForms kj_vs_I' lookup Alt3Forms;\012sub [kj_THA kj_PA kj_SA]' lookup AltForms kj_vs_II' lookup Alt5Forms;\012sub [kj_KHA kj_NA]' lookup AltForms kj_vs_I' lookup Alt4Forms;\012sub [kj_KHA kj_NA]' lookup AltForms kj_vs_II' lookup Alt4Forms;\012sub [DDDRA kj_TTA kj_TTHA kj_DDDA]' kj_vs_I' lookup Alt2Forms;\012sub [KSSA GNA kj_KA kj_QA kj_HA]' lookup AltForms kj_vs_I';\012sub [KSSA GNA kj_KA kj_QA kj_HA]' lookup AltForms kj_vs_II' lookup AltForms;\012sub [kj_NGA kj_NYA]' kj_vs_I' lookup Alt2Forms;\012sub [kj_NGA kj_NYA]' kj_vs_II' lookup Alt3Forms;\012";
 name = psts;
 },
 {
@@ -411,7 +420,7 @@ xHeight = 545;
 glyphs = (
 {
 glyphname = .notdef;
-lastChange = "2018-11-05 20:01:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -442,7 +451,7 @@ note = ".notdef";
 },
 {
 glyphname = NULL;
-lastChange = "2018-11-05 20:01:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -454,7 +463,7 @@ unicode = 0000;
 },
 {
 glyphname = CR;
-lastChange = "2018-11-05 20:01:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -466,7 +475,7 @@ unicode = 000D;
 },
 {
 glyphname = space;
-lastChange = "2018-11-05 20:01:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -480,7 +489,7 @@ subCategory = Space;
 },
 {
 glyphname = uni00A0;
-lastChange = "2018-11-05 20:01:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -494,7 +503,7 @@ subCategory = Space;
 },
 {
 glyphname = uni200C;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -507,7 +516,7 @@ category = Separator;
 },
 {
 glyphname = uni200D;
-lastChange = "2018-11-05 20:01:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -520,7 +529,7 @@ category = Separator;
 },
 {
 glyphname = uni25CC;
-lastChange = "2018-11-05 20:04:36 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -825,7 +834,7 @@ category = Letter;
 },
 {
 glyphname = uni0AE6;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -874,7 +883,7 @@ category = Letter;
 },
 {
 glyphname = uni0AE7;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -944,7 +953,7 @@ category = Letter;
 },
 {
 glyphname = uni0AE8;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1023,7 +1032,7 @@ category = Letter;
 },
 {
 glyphname = uni0AE9;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1099,7 +1108,7 @@ category = Letter;
 },
 {
 glyphname = uni0AEA;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1184,7 +1193,7 @@ category = Letter;
 },
 {
 glyphname = uni0AEB;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1257,7 +1266,7 @@ category = Letter;
 },
 {
 glyphname = uni0AEC;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1349,7 +1358,7 @@ category = Letter;
 },
 {
 glyphname = uni0AED;
-lastChange = "2018-11-05 20:23:21 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1417,7 +1426,7 @@ category = Letter;
 },
 {
 glyphname = uni0AEE;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1475,7 +1484,7 @@ category = Letter;
 },
 {
 glyphname = uni0AEF;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1556,7 +1565,7 @@ category = Letter;
 },
 {
 glyphname = uniA830;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1590,7 +1599,7 @@ category = Letter;
 },
 {
 glyphname = uniA831;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1643,7 +1652,7 @@ category = Letter;
 },
 {
 glyphname = uniA832;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1715,7 +1724,7 @@ category = Letter;
 },
 {
 glyphname = uniA833;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1755,7 +1764,7 @@ category = Letter;
 },
 {
 glyphname = uniA834;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1820,7 +1829,7 @@ category = Letter;
 },
 {
 glyphname = uniA835;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1910,7 +1919,7 @@ category = Letter;
 },
 {
 glyphname = uniA836;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1959,7 +1968,7 @@ category = Letter;
 },
 {
 glyphname = uniA837;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -2022,7 +2031,7 @@ category = Letter;
 },
 {
 glyphname = uniA838;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -2078,7 +2087,7 @@ category = Letter;
 },
 {
 glyphname = uniA839;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -2143,7 +2152,7 @@ category = Letter;
 },
 {
 glyphname = Anusvara;
-lastChange = "2018-11-05 20:04:51 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -2186,7 +2195,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = Nukta;
-lastChange = "2018-11-05 20:04:51 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -2263,7 +2272,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = Shadda;
-lastChange = "2023-03-23 12:03:57 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -2342,7 +2351,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = u11238;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -2409,7 +2418,7 @@ unicode = 11238;
 },
 {
 glyphname = u11239;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 components = (
@@ -2432,7 +2441,7 @@ unicode = 11239;
 },
 {
 glyphname = u1123A;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -2480,7 +2489,7 @@ unicode = 1123A;
 },
 {
 glyphname = u1123B;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -2522,7 +2531,7 @@ unicode = 1123B;
 },
 {
 glyphname = u1123C;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -2592,7 +2601,7 @@ unicode = 1123C;
 },
 {
 glyphname = u1123D;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -2640,7 +2649,7 @@ unicode = 1123D;
 },
 {
 glyphname = u1123E;
-lastChange = "2018-11-05 20:04:51 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -2707,7 +2716,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = KA.alt;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -2799,8 +2808,122 @@ note = KA.alt;
 category = Letter;
 },
 {
+glyphname = QA.alt;
+lastChange = "2023-06-26 11:59:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor7;
+position = "{440, 680}";
+}
+);
+layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 394 LINE",
+"182 358 OFFCURVE",
+"155 340 OFFCURVE",
+"115 340 CURVE SMOOTH",
+"70 340 OFFCURVE",
+"49 366 OFFCURVE",
+"49 410 CURVE SMOOTH",
+"49 455 OFFCURVE",
+"77 482 OFFCURVE",
+"116 482 CURVE SMOOTH",
+"156 482 OFFCURVE",
+"190 443 OFFCURVE",
+"190 363 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"179 321 LINE",
+"165 299 OFFCURVE",
+"153 282 OFFCURVE",
+"128 232 CURVE SMOOTH",
+"28 32 LINE SMOOTH",
+"26 29 OFFCURVE",
+"25 24 OFFCURVE",
+"25 21 CURVE SMOOTH",
+"25 4 OFFCURVE",
+"46 -12 OFFCURVE",
+"68 -12 CURVE SMOOTH",
+"81 -12 OFFCURVE",
+"95 -6 OFFCURVE",
+"103 10 CURVE SMOOTH",
+"195 192 LINE SMOOTH",
+"313 425 OFFCURVE",
+"391 480 OFFCURVE",
+"463 480 CURVE SMOOTH",
+"512 480 OFFCURVE",
+"520 440 OFFCURVE",
+"520 417 CURVE SMOOTH",
+"520 363 OFFCURVE",
+"471 263 OFFCURVE",
+"430 180 CURVE SMOOTH",
+"357 31 LINE SMOOTH",
+"355 27 OFFCURVE",
+"354 24 OFFCURVE",
+"354 20 CURVE SMOOTH",
+"354 2 OFFCURVE",
+"376 -12 OFFCURVE",
+"398 -12 CURVE SMOOTH",
+"413 -12 OFFCURVE",
+"427 -6 OFFCURVE",
+"435 10 CURVE SMOOTH",
+"453 46 LINE SMOOTH",
+"506 152 OFFCURVE",
+"592 181 OFFCURVE",
+"639 181 CURVE SMOOTH",
+"667 181 OFFCURVE",
+"695 178 OFFCURVE",
+"725 173 CURVE",
+"737 247 LINE",
+"702 253 OFFCURVE",
+"670 256 OFFCURVE",
+"638 256 CURVE SMOOTH",
+"607 256 OFFCURVE",
+"576 250 OFFCURVE",
+"545 238 CURVE",
+"581 315 OFFCURVE",
+"603 373 OFFCURVE",
+"603 424 CURVE SMOOTH",
+"603 499 OFFCURVE",
+"571 560 OFFCURVE",
+"473 560 CURVE SMOOTH",
+"393 560 OFFCURVE",
+"314 519 OFFCURVE",
+"242 419 CURVE",
+"254 419 LINE",
+"252 431 LINE",
+"235 526 OFFCURVE",
+"179 556 OFFCURVE",
+"110 556 CURVE SMOOTH",
+"26 556 OFFCURVE",
+"-29 498 OFFCURVE",
+"-29 407 CURVE SMOOTH",
+"-29 330 OFFCURVE",
+"28 276 OFFCURVE",
+"123 276 CURVE SMOOTH",
+"159 276 OFFCURVE",
+"176 287 OFFCURVE",
+"192 299 CURVE"
+);
+}
+);
+width = 637;
+}
+);
+note = KA.alt;
+category = Letter;
+},
+{
 glyphname = II.alt;
-lastChange = "2018-11-05 20:04:25 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -2877,7 +3000,7 @@ category = Letter;
 },
 {
 glyphname = KU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -3013,8 +3136,127 @@ note = KU;
 category = Letter;
 },
 {
+glyphname = QU;
+lastChange = "2023-06-26 11:59:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor7;
+position = "{373, 620}";
+},
+{
+name = Anchor9;
+position = "{681, 660}";
+}
+);
+layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
+paths = (
+{
+closed = 1;
+nodes = (
+"39 -40 OFFCURVE",
+"181 -158 OFFCURVE",
+"394 -158 CURVE SMOOTH",
+"591 -158 OFFCURVE",
+"716 -67 OFFCURVE",
+"716 100 CURVE SMOOTH",
+"716 208 OFFCURVE",
+"649 283 OFFCURVE",
+"556 283 CURVE SMOOTH",
+"531 283 OFFCURVE",
+"520 279 OFFCURVE",
+"492 269 CURVE",
+"471 206 LINE",
+"482 211 OFFCURVE",
+"511 213 OFFCURVE",
+"524 213 CURVE SMOOTH",
+"595 213 OFFCURVE",
+"641 187 OFFCURVE",
+"641 111 CURVE SMOOTH",
+"641 -14 OFFCURVE",
+"525 -76 OFFCURVE",
+"385 -76 CURVE SMOOTH",
+"246 -76 OFFCURVE",
+"145 -18 OFFCURVE",
+"106 53 CURVE SMOOTH",
+"82 97 OFFCURVE",
+"81 115 OFFCURVE",
+"64 115 CURVE SMOOTH",
+"46 115 OFFCURVE",
+"39 83 OFFCURVE",
+"39 54 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"242 262 OFFCURVE",
+"284 292 OFFCURVE",
+"338 347 CURVE SMOOTH",
+"368 378 LINE SMOOTH",
+"431 443 OFFCURVE",
+"465 481 OFFCURVE",
+"506 481 CURVE SMOOTH",
+"538 481 OFFCURVE",
+"553 460 OFFCURVE",
+"553 438 CURVE SMOOTH",
+"553 370 OFFCURVE",
+"429 246 OFFCURVE",
+"305 141 CURVE SMOOTH",
+"300 137 OFFCURVE",
+"296 132 OFFCURVE",
+"296 122 CURVE SMOOTH",
+"296 104 OFFCURVE",
+"321 79 OFFCURVE",
+"353 79 CURVE SMOOTH",
+"381 79 OFFCURVE",
+"399 97 OFFCURVE",
+"435 133 CURVE SMOOTH",
+"508 206 OFFCURVE",
+"631 332 OFFCURVE",
+"631 422 CURVE SMOOTH",
+"631 484 OFFCURVE",
+"585 558 OFFCURVE",
+"491 558 CURVE SMOOTH",
+"437 558 OFFCURVE",
+"385 515 OFFCURVE",
+"321 445 CURVE SMOOTH",
+"290 411 LINE SMOOTH",
+"234 350 OFFCURVE",
+"217 336 OFFCURVE",
+"179 336 CURVE SMOOTH",
+"134 336 OFFCURVE",
+"113 362 OFFCURVE",
+"113 406 CURVE SMOOTH",
+"113 450 OFFCURVE",
+"143 476 OFFCURVE",
+"185 476 CURVE SMOOTH",
+"243 476 OFFCURVE",
+"267 398 OFFCURVE",
+"274 334 CURVE",
+"326 386 LINE",
+"318 444 OFFCURVE",
+"285 552 OFFCURVE",
+"175 552 CURVE SMOOTH",
+"90 552 OFFCURVE",
+"35 494 OFFCURVE",
+"35 403 CURVE SMOOTH",
+"35 320 OFFCURVE",
+"92 262 OFFCURVE",
+"187 262 CURVE SMOOTH"
+);
+}
+);
+width = 771;
+}
+);
+note = KU;
+category = Letter;
+},
+{
 glyphname = GHU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -3130,7 +3372,7 @@ category = Letter;
 },
 {
 glyphname = CU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -3230,7 +3472,7 @@ category = Letter;
 },
 {
 glyphname = II.alt2;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -3305,7 +3547,7 @@ category = Letter;
 },
 {
 glyphname = I.alt;
-lastChange = "2018-11-05 20:04:48 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -3359,7 +3601,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = U.alt;
-lastChange = "2018-11-05 20:04:56 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -3416,7 +3658,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = GU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -3518,7 +3760,7 @@ category = Letter;
 },
 {
 glyphname = I.alt2;
-lastChange = "2018-11-05 20:04:48 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -3567,7 +3809,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = NGU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -3708,7 +3950,7 @@ category = Letter;
 },
 {
 glyphname = CHU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -3838,7 +4080,7 @@ category = Letter;
 },
 {
 glyphname = JU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -3963,7 +4205,7 @@ category = Letter;
 },
 {
 glyphname = U.alt2;
-lastChange = "2018-11-05 20:04:56 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -4028,7 +4270,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = DDU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -4178,7 +4420,7 @@ category = Letter;
 },
 {
 glyphname = DDHU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -4287,7 +4529,7 @@ category = Letter;
 },
 {
 glyphname = NNU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -4411,7 +4653,7 @@ category = Letter;
 },
 {
 glyphname = TU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -4498,7 +4740,7 @@ category = Letter;
 },
 {
 glyphname = THU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -4618,7 +4860,7 @@ category = Letter;
 },
 {
 glyphname = DI;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -4735,7 +4977,7 @@ category = Letter;
 },
 {
 glyphname = DII;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -4875,7 +5117,7 @@ category = Letter;
 },
 {
 glyphname = DU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -4998,7 +5240,7 @@ category = Letter;
 },
 {
 glyphname = I.alt3;
-lastChange = "2018-11-05 20:04:48 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -5049,7 +5291,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = I.alt4;
-lastChange = "2018-11-05 20:04:48 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -5098,7 +5340,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = II.alt3;
-lastChange = "2018-11-05 20:04:25 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -5170,7 +5412,7 @@ category = Letter;
 },
 {
 glyphname = NU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -5277,7 +5519,7 @@ category = Letter;
 },
 {
 glyphname = PU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -5373,7 +5615,7 @@ category = Letter;
 },
 {
 glyphname = PHI;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -5506,7 +5748,7 @@ category = Letter;
 },
 {
 glyphname = PHII;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -5663,7 +5905,7 @@ category = Letter;
 },
 {
 glyphname = PHU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -5796,7 +6038,7 @@ category = Letter;
 },
 {
 glyphname = BU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -5919,7 +6161,7 @@ category = Letter;
 },
 {
 glyphname = BBU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -6018,7 +6260,7 @@ category = Letter;
 },
 {
 glyphname = BHU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -6129,7 +6371,7 @@ category = Letter;
 },
 {
 glyphname = MU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -6235,7 +6477,7 @@ category = Letter;
 },
 {
 glyphname = YU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -6364,7 +6606,7 @@ category = Letter;
 },
 {
 glyphname = RI;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -6479,7 +6721,7 @@ category = Letter;
 },
 {
 glyphname = RII;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -6620,7 +6862,7 @@ category = Letter;
 },
 {
 glyphname = RU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -6709,7 +6951,7 @@ category = Letter;
 },
 {
 glyphname = LU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -6806,7 +7048,7 @@ category = Letter;
 },
 {
 glyphname = VU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -6897,7 +7139,7 @@ category = Letter;
 },
 {
 glyphname = SU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -7032,7 +7274,7 @@ category = Letter;
 },
 {
 glyphname = HA.alt;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -7115,7 +7357,7 @@ category = Letter;
 },
 {
 glyphname = HU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -7242,7 +7484,7 @@ category = Letter;
 },
 {
 glyphname = LLU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -7389,7 +7631,7 @@ category = Letter;
 },
 {
 glyphname = U.alt3;
-lastChange = "2018-11-05 20:04:56 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -7454,7 +7696,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = KSSA;
-lastChange = "2018-11-05 20:04:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -7607,7 +7849,7 @@ category = Letter;
 },
 {
 glyphname = KSSA.alt;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -7716,7 +7958,7 @@ category = Letter;
 },
 {
 glyphname = GNA;
-lastChange = "2018-11-05 20:04:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -7860,7 +8102,7 @@ category = Letter;
 },
 {
 glyphname = TRA;
-lastChange = "2018-11-05 20:04:36 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -7954,7 +8196,7 @@ category = Letter;
 },
 {
 glyphname = TRU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -8044,7 +8286,7 @@ category = Letter;
 },
 {
 glyphname = DDDRA;
-lastChange = "2018-11-05 20:04:36 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -8169,7 +8411,7 @@ category = Letter;
 },
 {
 glyphname = DDDRU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -8305,7 +8547,7 @@ category = Letter;
 },
 {
 glyphname = DDDU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -8425,7 +8667,7 @@ category = Letter;
 },
 {
 glyphname = NYU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -8574,7 +8816,7 @@ category = Letter;
 },
 {
 glyphname = GNA.alt;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -8672,7 +8914,7 @@ category = Letter;
 },
 {
 glyphname = RA.alt;
-lastChange = "2018-11-05 20:04:45 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -8718,7 +8960,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = YA.alt;
-lastChange = "2018-11-05 20:04:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -8827,7 +9069,7 @@ category = Letter;
 },
 {
 glyphname = YA.alt2;
-lastChange = "2018-11-05 20:04:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -8943,7 +9185,7 @@ category = Letter;
 },
 {
 glyphname = YA.alt3;
-lastChange = "2018-11-05 20:04:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -9022,7 +9264,7 @@ category = Letter;
 },
 {
 glyphname = Nukta.alt;
-lastChange = "2018-11-05 20:04:51 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -9098,7 +9340,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = Anusvara.alt;
-lastChange = "2018-11-05 20:04:51 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -9153,7 +9395,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = kj_A;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -9255,7 +9497,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_AA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -9387,8 +9629,107 @@ category = Letter;
 subCategory = Spacing;
 },
 {
+glyphname = kj_Ishort;
+lastChange = "2023-06-26 12:10:35 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor7;
+position = "{241, 620}";
+},
+{
+name = Anchor9;
+position = "{241, 620}";
+}
+);
+layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
+paths = (
+{
+closed = 1;
+nodes = (
+"35 444 OFFCURVE",
+"67 413 OFFCURVE",
+"108 413 CURVE SMOOTH",
+"149 413 OFFCURVE",
+"182 444 OFFCURVE",
+"182 482 CURVE SMOOTH",
+"182 520 OFFCURVE",
+"149 552 OFFCURVE",
+"108 552 CURVE SMOOTH",
+"67 552 OFFCURVE",
+"35 520 OFFCURVE",
+"35 482 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"295 444 OFFCURVE",
+"327 413 OFFCURVE",
+"368 413 CURVE SMOOTH",
+"409 413 OFFCURVE",
+"442 444 OFFCURVE",
+"442 482 CURVE SMOOTH",
+"442 520 OFFCURVE",
+"409 552 OFFCURVE",
+"368 552 CURVE SMOOTH",
+"327 552 OFFCURVE",
+"295 520 OFFCURVE",
+"295 482 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"274 289 OFFCURVE",
+"267 275 OFFCURVE",
+"267 255 CURVE SMOOTH",
+"267 239 OFFCURVE",
+"273 220 OFFCURVE",
+"283 215 CURVE",
+"366 200 OFFCURVE",
+"398 176 OFFCURVE",
+"398 146 CURVE SMOOTH",
+"398 97 OFFCURVE",
+"324 84 OFFCURVE",
+"255 84 CURVE SMOOTH",
+"165 84 OFFCURVE",
+"118 107 OFFCURVE",
+"110 222 CURVE SMOOTH",
+"108 250 OFFCURVE",
+"101 268 OFFCURVE",
+"84 268 CURVE SMOOTH",
+"62 268 OFFCURVE",
+"35 219 OFFCURVE",
+"35 182 CURVE SMOOTH",
+"35 135 OFFCURVE",
+"56 75 OFFCURVE",
+"102 41 CURVE SMOOTH",
+"146 8 OFFCURVE",
+"197 -1 OFFCURVE",
+"270 -1 CURVE SMOOTH",
+"392 -1 OFFCURVE",
+"476 36 OFFCURVE",
+"476 123 CURVE SMOOTH",
+"476 223 OFFCURVE",
+"383 299 OFFCURVE",
+"289 299 CURVE"
+);
+}
+);
+width = 506;
+}
+);
+note = kj_I;
+unicode = 11240;
+script = khojki;
+category = Letter;
+subCategory = Spacing;
+},
+{
 glyphname = kj_I;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -9539,7 +9880,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_U;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -9639,7 +9980,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_E;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -9753,7 +10094,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_AI;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -9782,7 +10123,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_O;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -9853,7 +10194,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_AU;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -9884,7 +10225,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_KA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -10021,8 +10362,138 @@ category = Letter;
 subCategory = Spacing;
 },
 {
+glyphname = kj_QA;
+lastChange = "2023-06-26 12:11:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor11;
+position = "{578, 620}";
+},
+{
+name = Anchor13;
+position = "{435, 0}";
+},
+{
+name = Anchor7;
+position = "{445, 620}";
+},
+{
+name = Anchor9;
+position = "{693, 660}";
+}
+);
+guideLines = (
+{
+position = "{391, 558}";
+}
+);
+layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
+paths = (
+{
+closed = 1;
+nodes = (
+"497 211 OFFCURVE",
+"526 213 OFFCURVE",
+"539 213 CURVE SMOOTH",
+"577 213 OFFCURVE",
+"595 175 OFFCURVE",
+"599 133 CURVE SMOOTH",
+"606 56 OFFCURVE",
+"627 -4 OFFCURVE",
+"698 -4 CURVE SMOOTH",
+"733 -4 OFFCURVE",
+"743 17 OFFCURVE",
+"743 37 CURVE SMOOTH",
+"743 52 OFFCURVE",
+"737 67 OFFCURVE",
+"719 67 CURVE SMOOTH",
+"668 67 OFFCURVE",
+"676 132 OFFCURVE",
+"668 175 CURVE SMOOTH",
+"658 229 OFFCURVE",
+"636 283 OFFCURVE",
+"558 283 CURVE SMOOTH",
+"543 283 OFFCURVE",
+"530 278 OFFCURVE",
+"507 269 CURVE",
+"486 206 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"257 262 OFFCURVE",
+"299 292 OFFCURVE",
+"353 347 CURVE SMOOTH",
+"383 378 LINE SMOOTH",
+"446 443 OFFCURVE",
+"480 481 OFFCURVE",
+"521 481 CURVE SMOOTH",
+"553 481 OFFCURVE",
+"568 460 OFFCURVE",
+"568 438 CURVE SMOOTH",
+"568 370 OFFCURVE",
+"444 246 OFFCURVE",
+"320 141 CURVE SMOOTH",
+"315 137 OFFCURVE",
+"311 132 OFFCURVE",
+"311 122 CURVE SMOOTH",
+"311 104 OFFCURVE",
+"336 79 OFFCURVE",
+"368 79 CURVE SMOOTH",
+"396 79 OFFCURVE",
+"414 97 OFFCURVE",
+"450 133 CURVE SMOOTH",
+"523 206 OFFCURVE",
+"646 332 OFFCURVE",
+"646 422 CURVE SMOOTH",
+"646 484 OFFCURVE",
+"600 558 OFFCURVE",
+"506 558 CURVE SMOOTH",
+"452 558 OFFCURVE",
+"400 515 OFFCURVE",
+"336 445 CURVE SMOOTH",
+"305 411 LINE SMOOTH",
+"249 350 OFFCURVE",
+"232 336 OFFCURVE",
+"194 336 CURVE SMOOTH",
+"149 336 OFFCURVE",
+"128 362 OFFCURVE",
+"128 406 CURVE SMOOTH",
+"128 450 OFFCURVE",
+"158 476 OFFCURVE",
+"200 476 CURVE SMOOTH",
+"258 476 OFFCURVE",
+"282 398 OFFCURVE",
+"289 334 CURVE",
+"341 386 LINE",
+"333 444 OFFCURVE",
+"300 552 OFFCURVE",
+"190 552 CURVE SMOOTH",
+"105 552 OFFCURVE",
+"50 494 OFFCURVE",
+"50 403 CURVE SMOOTH",
+"50 320 OFFCURVE",
+"107 262 OFFCURVE",
+"202 262 CURVE SMOOTH"
+);
+}
+);
+width = 788;
+}
+);
+leftMetricsKey = kj_YA;
+rightMetricsKey = kj_KA;
+unicode = 1123F;
+script = khojki;
+category = Letter;
+subCategory = Spacing;
+},
+{
 glyphname = kj_KHA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -10139,7 +10610,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_GA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -10247,7 +10718,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_GGA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -10384,7 +10855,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_GHA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -10511,7 +10982,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_NGA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -10590,7 +11061,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_CA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -10697,7 +11168,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_CHA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -10807,7 +11278,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_JA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -10938,7 +11409,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_JJA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -11069,7 +11540,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_NYA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -11148,7 +11619,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_TTA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -11254,7 +11725,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_TTHA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -11347,7 +11818,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_DDA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -11511,7 +11982,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_DDHA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -11610,7 +12081,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_NNA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -11748,7 +12219,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_TA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -11844,7 +12315,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_THA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -11980,7 +12451,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_DA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -12093,7 +12564,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_DDDA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -12193,7 +12664,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_DHA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -12301,7 +12772,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_NA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -12407,7 +12878,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_PA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -12510,7 +12981,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_PHA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -12629,7 +13100,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_BA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -12760,7 +13231,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_BBA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -12865,7 +13336,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_BHA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -12984,7 +13455,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_MA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -13096,7 +13567,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_YA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -13232,7 +13703,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_RA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -13322,7 +13793,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_LA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -13427,7 +13898,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_VA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -13526,7 +13997,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_SA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -13600,7 +14071,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_HA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -13710,7 +14181,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_LLA;
-lastChange = "2022-02-01 16:33:04 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -13834,7 +14305,7 @@ subCategory = Spacing;
 },
 {
 glyphname = kj_vs_AA;
-lastChange = "2022-02-01 16:33:20 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -13893,7 +14364,7 @@ subCategory = "Spacing Combining";
 },
 {
 glyphname = kj_vs_I;
-lastChange = "2022-02-01 16:33:26 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -13955,7 +14426,7 @@ subCategory = "Spacing Combining";
 },
 {
 glyphname = kj_vs_II;
-lastChange = "2022-02-01 16:33:32 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -14030,7 +14501,7 @@ subCategory = "Spacing Combining";
 },
 {
 glyphname = kj_vs_U.ns;
-lastChange = "2018-11-05 20:04:56 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -14088,7 +14559,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = kj_vs_E.ns;
-lastChange = "2023-03-23 12:10:08 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -14147,7 +14618,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = kj_vs_AI.ns;
-lastChange = "2023-03-23 12:12:56 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -14235,7 +14706,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = kj_vs_O;
-lastChange = "2022-02-15 09:22:37 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -14268,7 +14739,7 @@ subCategory = Other;
 },
 {
 glyphname = kj_vs_AU;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -14301,7 +14772,7 @@ category = Letter;
 },
 {
 glyphname = virama;
-lastChange = "2018-11-05 20:02:30 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -14340,7 +14811,7 @@ unicode = 11235;
 },
 {
 glyphname = DDII;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -14532,7 +15003,7 @@ category = Letter;
 },
 {
 glyphname = KHU;
-lastChange = "2018-11-05 20:04:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -14665,7 +15136,7 @@ category = Letter;
 },
 {
 glyphname = JJU;
-lastChange = "2018-11-05 20:04:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -14811,7 +15282,7 @@ category = Letter;
 },
 {
 glyphname = LLII;
-lastChange = "2018-11-05 20:04:36 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -14971,7 +15442,7 @@ category = Letter;
 },
 {
 glyphname = BHRA;
-lastChange = "2018-11-05 20:04:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -15106,7 +15577,7 @@ category = Letter;
 },
 {
 glyphname = KRA;
-lastChange = "2018-11-05 20:04:36 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -15265,8 +15736,153 @@ width = 773;
 category = Letter;
 },
 {
+glyphname = QRA;
+lastChange = "2023-06-26 11:59:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor11;
+position = "{563, 620}";
+},
+{
+name = Anchor13;
+position = "{483, -54}";
+},
+{
+name = Anchor7;
+position = "{450, 620}";
+},
+{
+name = Anchor9;
+position = "{678, 660}";
+}
+);
+layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
+paths = (
+{
+closed = 1;
+nodes = (
+"482 211 OFFCURVE",
+"511 213 OFFCURVE",
+"524 213 CURVE SMOOTH",
+"562 213 OFFCURVE",
+"580 175 OFFCURVE",
+"584 133 CURVE SMOOTH",
+"591 56 OFFCURVE",
+"612 -4 OFFCURVE",
+"683 -4 CURVE SMOOTH",
+"718 -4 OFFCURVE",
+"728 17 OFFCURVE",
+"728 37 CURVE SMOOTH",
+"728 52 OFFCURVE",
+"722 67 OFFCURVE",
+"704 67 CURVE SMOOTH",
+"653 67 OFFCURVE",
+"661 132 OFFCURVE",
+"653 175 CURVE SMOOTH",
+"643 229 OFFCURVE",
+"621 283 OFFCURVE",
+"543 283 CURVE SMOOTH",
+"528 283 OFFCURVE",
+"515 278 OFFCURVE",
+"492 269 CURVE",
+"471 206 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"726 134 LINE SMOOTH",
+"732 142 OFFCURVE",
+"732 149 OFFCURVE",
+"730 159 CURVE SMOOTH",
+"726 180 OFFCURVE",
+"699 201 OFFCURVE",
+"678 197 CURVE SMOOTH",
+"673 196 OFFCURVE",
+"670 193 OFFCURVE",
+"667 189 CURVE SMOOTH",
+"461 -82 LINE SMOOTH",
+"451 -95 OFFCURVE",
+"452 -103 OFFCURVE",
+"455 -115 CURVE SMOOTH",
+"459 -132 OFFCURVE",
+"486 -149 OFFCURVE",
+"507 -144 CURVE SMOOTH",
+"515 -142 OFFCURVE",
+"522 -136 OFFCURVE",
+"525 -132 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"242 262 OFFCURVE",
+"284 292 OFFCURVE",
+"338 347 CURVE SMOOTH",
+"368 378 LINE SMOOTH",
+"431 443 OFFCURVE",
+"465 481 OFFCURVE",
+"506 481 CURVE SMOOTH",
+"538 481 OFFCURVE",
+"553 460 OFFCURVE",
+"553 438 CURVE SMOOTH",
+"553 370 OFFCURVE",
+"429 246 OFFCURVE",
+"305 141 CURVE SMOOTH",
+"300 137 OFFCURVE",
+"296 132 OFFCURVE",
+"296 122 CURVE SMOOTH",
+"296 104 OFFCURVE",
+"321 79 OFFCURVE",
+"353 79 CURVE SMOOTH",
+"381 79 OFFCURVE",
+"399 97 OFFCURVE",
+"435 133 CURVE SMOOTH",
+"508 206 OFFCURVE",
+"631 332 OFFCURVE",
+"631 422 CURVE SMOOTH",
+"631 484 OFFCURVE",
+"585 558 OFFCURVE",
+"491 558 CURVE SMOOTH",
+"437 558 OFFCURVE",
+"385 515 OFFCURVE",
+"321 445 CURVE SMOOTH",
+"290 411 LINE SMOOTH",
+"234 350 OFFCURVE",
+"217 336 OFFCURVE",
+"179 336 CURVE SMOOTH",
+"134 336 OFFCURVE",
+"113 362 OFFCURVE",
+"113 406 CURVE SMOOTH",
+"113 450 OFFCURVE",
+"143 476 OFFCURVE",
+"185 476 CURVE SMOOTH",
+"243 476 OFFCURVE",
+"267 398 OFFCURVE",
+"274 334 CURVE",
+"326 386 LINE",
+"318 444 OFFCURVE",
+"285 552 OFFCURVE",
+"175 552 CURVE SMOOTH",
+"90 552 OFFCURVE",
+"35 494 OFFCURVE",
+"35 403 CURVE SMOOTH",
+"35 320 OFFCURVE",
+"92 262 OFFCURVE",
+"187 262 CURVE SMOOTH"
+);
+}
+);
+width = 773;
+}
+);
+category = Letter;
+},
+{
 glyphname = MRA;
-lastChange = "2018-11-05 20:04:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -15400,7 +16016,7 @@ category = Letter;
 },
 {
 glyphname = SRA;
-lastChange = "2018-11-05 20:04:36 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -15563,7 +16179,7 @@ category = Letter;
 },
 {
 glyphname = THA.alt;
-lastChange = "2018-11-05 20:04:36 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -15694,7 +16310,7 @@ category = Letter;
 },
 {
 glyphname = PA.alt;
-lastChange = "2018-11-05 20:04:36 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -15798,7 +16414,7 @@ category = Letter;
 },
 {
 glyphname = KHA.alt;
-lastChange = "2018-11-05 20:04:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -15911,7 +16527,7 @@ category = Letter;
 },
 {
 glyphname = NA.alt;
-lastChange = "2018-11-05 20:04:36 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16005,7 +16621,7 @@ category = Letter;
 },
 {
 glyphname = SA.alt;
-lastChange = "2018-11-05 20:04:36 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16084,7 +16700,7 @@ category = Letter;
 },
 {
 glyphname = Ra_U;
-lastChange = "2018-11-05 20:04:45 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16111,7 +16727,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = II.alt4;
-lastChange = "2018-11-05 20:04:26 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16178,7 +16794,7 @@ category = Letter;
 },
 {
 glyphname = II.alt5;
-lastChange = "2018-11-05 20:04:26 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16242,7 +16858,7 @@ category = Letter;
 },
 {
 glyphname = DDDII;
-lastChange = "2018-11-05 20:04:34 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16370,7 +16986,7 @@ category = Letter;
 },
 {
 glyphname = DDDRII;
-lastChange = "2018-11-05 20:04:36 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16532,7 +17148,7 @@ category = Letter;
 },
 {
 glyphname = E_Shadda.ns;
-lastChange = "2018-11-05 20:04:54 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16560,7 +17176,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = AI_Shadda.ns;
-lastChange = "2018-11-05 20:04:54 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16589,7 +17205,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = Nukta_Shadda.ns;
-lastChange = "2018-11-05 20:04:51 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16713,7 +17329,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = Nukta_E.ns;
-lastChange = "2023-03-23 12:07:45 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16768,7 +17384,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = Nukta_AI.ns;
-lastChange = "2018-11-05 20:04:54 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16795,7 +17411,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = Nukta_Shadda_E.ns;
-lastChange = "2018-11-05 20:04:54 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16823,7 +17439,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = Nukta_Shadda_AI.ns;
-lastChange = "2018-11-05 20:04:54 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 anchors = (
@@ -16850,7 +17466,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = NullMark;
-lastChange = "2018-11-05 20:01:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -16863,7 +17479,7 @@ subCategory = Nonspacing;
 {
 export = 0;
 glyphname = RA.alt2;
-lastChange = "2018-11-05 20:01:39 +0000";
+lastChange = "2023-06-26 11:59:38 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -16949,5 +17565,5 @@ manufacturer = "Monotype Imaging Inc.";
 manufacturerURL = "http://www.google.com/get/noto/";
 unitsPerEm = 1000;
 versionMajor = 2;
-versionMinor = 4;
+versionMinor = 3;
 }

--- a/sources/NotoSerifKhojki.glyphs
+++ b/sources/NotoSerifKhojki.glyphs
@@ -1,8 +1,9 @@
 {
-.appVersion = "3180";
+.appVersion = "3151";
 .formatVersion = 3;
 DisplayStrings = (
-"/qa_iMatra-khoj/qa_iiMatra-khoj/qa_uMatra-khoj ◌"
+"𑈿/qa_iMatra-khoj/qa_iiMatra-khoj/qa_uMatra-khoj/q_ra_uMatra-khoj 
+𑈈/ka_iMatra-khoj/ka_iiMatra-khoj/ka_uMatra-khoj/k_ra_uMatra-khoj"
 );
 axes = (
 {
@@ -21,7 +22,7 @@ code = "ka_iMatra-khoj qa_iMatra-khoj k_ssa_iMatra-khoj k_ssa_ra_iMatra-khoj kha
 name = IMATRA;
 },
 {
-code = "a-khoj aa-khoj aaMatra-khoj ai-khoj au-khoj b_ra-khoj ba-khoj bba-khoj bha-khoj c_ra-khoj ca-khoj cha-khoj d_ra-khoj da-khoj dda-khoj ddda-khoj ddha-khoj dha-khoj e-khoj g_na-khoj g_na_ra-khoj g_ra-khoj ga-khoj gga-khoj gha-khoj h_ra-khoj ha-khoj i-khoj j_ra-khoj ja-khoj jja-khoj k_ssa-khoj k_ssa_ra-khoj ka-khoj qa-khoj kha-khoj l_ra-khoj la-khoj lla-khoj m_ra-khoj ma-khoj n_ra-khoj na-khoj nga-khoj nna-khoj nya-khoj o-khoj pa-khoj pha-khoj ra-khoj s_ra-khoj sa-khoj t_ra-khoj ta-khoj tha-khoj tta-khoj ttha-khoj u-khoj uni25CC v_ra-khoj va-khoj y_ra-khoj ya-khoj yakar-khoj
+code = "a-khoj aa-khoj aaMatra-khoj ai-khoj au-khoj b_ra-khoj ba-khoj bba-khoj bha-khoj c_ra-khoj ca-khoj cha-khoj d_ra-khoj da-khoj dda-khoj ddda-khoj ddha-khoj dha-khoj e-khoj g_na-khoj g_na_ra-khoj g_ra-khoj ga-khoj gga-khoj gha-khoj h_ra-khoj ha-khoj ishort-khoj i-khoj j_ra-khoj ja-khoj jja-khoj k_ssa-khoj k_ssa_ra-khoj ka-khoj qa-khoj kha-khoj l_ra-khoj la-khoj lla-khoj m_ra-khoj ma-khoj n_ra-khoj na-khoj nga-khoj nna-khoj nya-khoj o-khoj pa-khoj pha-khoj ra-khoj s_ra-khoj sa-khoj t_ra-khoj ta-khoj tha-khoj tta-khoj ttha-khoj u-khoj uni25CC v_ra-khoj va-khoj y_ra-khoj ya-khoj yakar-khoj
 ";
 name = BASES;
 }
@@ -51,6 +52,7 @@ uni25CC,
 "nine-khoj",
 "a-khoj",
 "aa-khoj",
+"ishort-khoj",
 "i-khoj",
 "u-khoj",
 "e-khoj",
@@ -76,6 +78,11 @@ uni25CC,
 "k_ssa_ra_iMatra-khoj",
 "k_ssa_ra_iiMatra-khoj",
 "k_ssa_ra_uMatra-khoj",
+"qa-khoj",
+"qa_iMatra-khoj",
+"qa_iiMatra-khoj",
+"qa_uMatra-khoj",
+"q_ra_uMatra-khoj",
 "kha-khoj",
 "kha_iMatra-khoj",
 "kha_iiMatra-khoj",
@@ -488,8 +495,9 @@ code = "lookup RakarU {
 
 lookup RakarForms {
 	sub [gha-khoj nga-khoj tta-khoj ttha-khoj lla-khoj ] halant-khoj' ra-khoj' by rakar-gujarati;
-	sub [ka-khoj cha-khoj nya-khoj ddha-khoj tha-khoj pa-khoj pha-khoj ] halant-khoj' ra-khoj' by rakar.alt;
-} RakarForms;";
+	sub [ka-khoj qa-khoj cha-khoj nya-khoj ddha-khoj tha-khoj pa-khoj pha-khoj ] halant-khoj' ra-khoj' by rakar.alt;
+} RakarForms;
+";
 tag = rkrf;
 },
 {
@@ -506,7 +514,7 @@ tag = rphf;
 },
 {
 code = "lookup YakarForms {
-	sub [ka-khoj kha-khoj ga-khoj gga-khoj gha-khoj nga-khoj ca-khoj cha-khoj ja-khoj jja-khoj nya-khoj tta-khoj ttha-khoj dda-khoj ddha-khoj nna-khoj ta-khoj tha-khoj da-khoj ddda-khoj dha-khoj na-khoj pa-khoj pha-khoj ba-khoj bba-khoj bha-khoj ma-khoj ya-khoj ra-khoj la-khoj va-khoj sa-khoj ha-khoj lla-khoj ] halant-khoj' ya-khoj' by yakar-khoj;
+	sub [ka-khoj kha-khoj ga-khoj gga-khoj gha-khoj nga-khoj ca-khoj cha-khoj ja-khoj jja-khoj nya-khoj tta-khoj ttha-khoj dda-khoj ddha-khoj nna-khoj ta-khoj tha-khoj da-khoj ddda-khoj dha-khoj na-khoj pa-khoj pha-khoj ba-khoj bba-khoj bha-khoj ma-khoj ya-khoj ra-khoj la-khoj va-khoj sa-khoj ha-khoj lla-khoj qa-khoj ] halant-khoj' ya-khoj' by yakar-khoj;
 } YakarForms;
 
 lookup YakarVowels {
@@ -809,7 +817,7 @@ tag = abvs;
 {
 code = "lookup YakarAlts {
 	sub [kha-khoj ga-khoj gga-khoj gha-khoj nga-khoj ca-khoj cha-khoj ja-khoj jja-khoj nya-khoj tta-khoj ttha-khoj dda-khoj ddha-khoj ta-khoj tha-khoj dha-khoj na-khoj pa-khoj ba-khoj bba-khoj bha-khoj ma-khoj ya-khoj ra-khoj la-khoj va-khoj sa-khoj lla-khoj ] yakar_uMatra-khoj' by yakar_uMatra-khoj.alt;
-	sub [ka-khoj da-khoj ddda-khoj ha-khoj nna-khoj pha-khoj d_ra-khoj ] yakar_uMatra-khoj' by yakar_uMatra-khoj.alt2;
+	sub [ka-khoj qa-khoj da-khoj ddda-khoj ha-khoj nna-khoj pha-khoj d_ra-khoj ] yakar_uMatra-khoj' by yakar_uMatra-khoj.alt2;
 } YakarAlts;
 ";
 tag = psts;
@@ -1125,7 +1133,7 @@ GSOffsetVertical = 22;
 glyphs = (
 {
 glyphname = .notdef;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1180,7 +1188,7 @@ note = ".notdef";
 },
 {
 glyphname = NULL;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1196,7 +1204,7 @@ unicode = 0;
 },
 {
 glyphname = CR;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1213,7 +1221,7 @@ unicode = 13;
 {
 category = Separator;
 glyphname = space;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1231,7 +1239,7 @@ unicode = 32;
 {
 category = Separator;
 glyphname = uni00A0;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1249,7 +1257,7 @@ unicode = 160;
 {
 category = Separator;
 glyphname = uni200D;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1266,7 +1274,7 @@ unicode = 8205;
 {
 category = Letter;
 glyphname = uni25CC;
-lastChange = "2023-03-23 12:39:55 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -1858,11 +1866,10 @@ unicode = 9676;
 },
 {
 category = Number;
-color = 6;
 glyphname = "zero-khoj";
 kernLeft = ZERO;
 kernRight = ZERO;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -1951,11 +1958,10 @@ unicode = 2790;
 },
 {
 category = Number;
-color = 6;
 glyphname = "one-khoj";
 kernLeft = ONE;
 kernRight = PA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -2089,11 +2095,10 @@ unicode = 2791;
 },
 {
 category = Number;
-color = 6;
 glyphname = "two-khoj";
 kernLeft = TWO;
 kernRight = TWO;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -2246,11 +2251,10 @@ unicode = 2792;
 },
 {
 category = Number;
-color = 6;
 glyphname = "three-khoj";
 kernLeft = THREE;
 kernRight = THREE;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -2395,11 +2399,10 @@ unicode = 2793;
 },
 {
 category = Number;
-color = 6;
 glyphname = "four-khoj";
 kernLeft = FOUR;
 kernRight = FOUR;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -2520,11 +2523,10 @@ unicode = 2794;
 },
 {
 category = Number;
-color = 6;
 glyphname = "five-khoj";
 kernLeft = PA;
 kernRight = PA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -2675,11 +2677,10 @@ unicode = 2795;
 },
 {
 category = Number;
-color = 6;
 glyphname = "six-khoj";
 kernLeft = SIX;
 kernRight = SIX;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -2848,11 +2849,10 @@ unicode = 2796;
 },
 {
 category = Letter;
-color = 10;
 glyphname = "six-khoj.alt";
 kernLeft = SIX;
 kernRight = SIX;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -3000,11 +3000,10 @@ script = khoj;
 },
 {
 category = Number;
-color = 6;
 glyphname = "seven-khoj";
 kernLeft = SEVEN;
 kernRight = SEVEN;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -3125,11 +3124,10 @@ unicode = 2797;
 },
 {
 category = Number;
-color = 6;
 glyphname = "eight-khoj";
 kernLeft = EIGHT;
 kernRight = EIGHT;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -3210,11 +3208,10 @@ unicode = 2798;
 },
 {
 category = Number;
-color = 6;
 glyphname = "nine-khoj";
 kernLeft = NINE;
 kernRight = TWO;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -3342,11 +3339,10 @@ unicode = 2799;
 },
 {
 category = Letter;
-color = 8;
 glyphname = "a-khoj";
 kernLeft = A;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -3513,11 +3509,10 @@ unicode = 70144;
 },
 {
 category = Letter;
-color = 8;
 glyphname = "aa-khoj";
 kernLeft = A;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -3576,11 +3571,203 @@ unicode = 70145;
 },
 {
 category = Letter;
-color = 8;
+glyphname = "ishort-khoj";
+lastChange = "2023-06-05 09:48:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = nukta;
+pos = (261,527);
+},
+{
+name = top;
+pos = (337,532);
+}
+);
+layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,-4,o),
+(516,65,o),
+(516,163,cs),
+(516,264,o),
+(431,365,o),
+(369,365,cs),
+(355,365,o),
+(335,360,o),
+(320,355,cs),
+(306,350,ls),
+(279,340,o),
+(268,345,o),
+(261,358,cs),
+(251,378,l),
+(220,368,l),
+(270,265,ls),
+(281,243,o),
+(293,239,o),
+(332,254,cs),
+(353,262,ls),
+(372,269,o),
+(391,272,o),
+(406,272,cs),
+(437,272,o),
+(451,245,o),
+(451,215,cs),
+(451,140,o),
+(379,92,o),
+(302,92,cs),
+(203,92,o),
+(139,178,o),
+(84,298,c),
+(79,299,l),
+(51,261,l),
+(110,111,o),
+(208,-4,o),
+(338,-4,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(155,415,o),
+(185,444,o),
+(185,490,cs),
+(185,539,o),
+(155,570,o),
+(107,570,cs),
+(60,570,o),
+(30,539,o),
+(30,490,cs),
+(30,444,o),
+(60,415,o),
+(107,415,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(462,441,o),
+(492,470,o),
+(492,516,cs),
+(492,565,o),
+(462,596,o),
+(414,596,cs),
+(367,596,o),
+(337,565,o),
+(337,516,cs),
+(337,470,o),
+(367,441,o),
+(414,441,cs)
+);
+}
+);
+width = 594;
+},
+{
+anchors = (
+{
+name = nukta;
+pos = (276,582);
+},
+{
+name = top;
+pos = (375,592);
+}
+);
+layerId = "A430B39A-257A-41FC-BEA9-652C696FFEF7";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,-28,o),
+(568,53,o),
+(568,160,cs),
+(568,279,o),
+(475,390,o),
+(403,390,cs),
+(392,390,o),
+(376,390,o),
+(354,382,cs),
+(337,376,ls),
+(324,371,o),
+(315,375,o),
+(310,384,cs),
+(296,411,l),
+(244,391,l),
+(306,256,ls),
+(320,226,o),
+(339,223,o),
+(366,231,cs),
+(425,248,ls),
+(435,251,o),
+(441,251,o),
+(445,251,cs),
+(466,251,o),
+(476,233,o),
+(476,210,cs),
+(476,156,o),
+(414,114,o),
+(338,114,cs),
+(247,114,o),
+(181,167,o),
+(116,319,c),
+(105,320,l),
+(61,263,l),
+(131,78,o),
+(243,-28,o),
+(376,-28,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,407,o),
+(220,445,o),
+(220,503,cs),
+(220,561,o),
+(182,602,o),
+(122,602,cs),
+(64,602,o),
+(25,562,o),
+(25,502,cs),
+(25,445,o),
+(64,407,o),
+(122,407,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(511,447,o),
+(550,485,o),
+(550,543,cs),
+(550,601,o),
+(512,642,o),
+(452,642,cs),
+(394,642,o),
+(355,602,o),
+(355,542,cs),
+(355,485,o),
+(394,447,o),
+(452,447,cs)
+);
+}
+);
+width = 612;
+}
+);
+script = khojki;
+unicode = 70208;
+},
+{
+category = Letter;
 glyphname = "i-khoj";
 kernLeft = GA;
 kernRight = II;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -3838,11 +4025,10 @@ unicode = 70146;
 },
 {
 category = Letter;
-color = 8;
 glyphname = "u-khoj";
 kernLeft = KU;
 kernRight = U;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -4043,11 +4229,10 @@ unicode = 70147;
 },
 {
 category = Letter;
-color = 8;
 glyphname = "e-khoj";
 kernLeft = PA;
 kernRight = E;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -4241,11 +4426,10 @@ unicode = 70148;
 },
 {
 category = Letter;
-color = 8;
 glyphname = "ai-khoj";
 kernLeft = A;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -4302,11 +4486,10 @@ unicode = 70149;
 },
 {
 category = Letter;
-color = 8;
 glyphname = "o-khoj";
 kernLeft = GGA;
 kernRight = O;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -4435,11 +4618,10 @@ unicode = 70150;
 },
 {
 category = Letter;
-color = 8;
 glyphname = "au-khoj";
 kernLeft = A;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -4497,11 +4679,10 @@ script = khoj;
 unicode = 70151;
 },
 {
-color = 10;
 export = 0;
 glyphname = "rVocalic-gujarati";
 kernLeft = GGA;
-lastChange = "2022-04-15 21:56:04 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -4755,11 +4936,10 @@ unicode = 2699;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ka-khoj";
 kernLeft = KA;
 kernRight = KA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -5009,11 +5189,10 @@ script = khoj;
 unicode = 70152;
 },
 {
-color = 1;
 glyphname = "ka_iMatra-khoj";
 kernLeft = KA;
 kernRight = HI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -5288,11 +5467,10 @@ metricRight = "ha_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "ka_iiMatra-khoj";
 kernLeft = KA;
 kernRight = HII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -5597,11 +5775,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ka_uMatra-khoj";
 kernLeft = KU;
 kernRight = KA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -5829,11 +6006,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "k_ra_uMatra-khoj";
 kernLeft = KU;
 kernRight = KA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -6082,11 +6258,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "k_ssa-khoj";
 kernLeft = KSSA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -6354,11 +6529,10 @@ note = KSSA;
 script = khoj;
 },
 {
-color = 1;
 glyphname = "k_ssa_iMatra-khoj";
 kernLeft = KSSA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -6664,11 +6838,10 @@ metricRight = "gga_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "k_ssa_iiMatra-khoj";
 kernLeft = KSSA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -7012,11 +7185,10 @@ metricRight = "gga_iiMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "k_ssa_uMatra-khoj";
 kernLeft = LU;
 kernRight = KHU;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -7344,11 +7516,10 @@ width = 863;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "k_ssa_ra-khoj";
 kernLeft = KSSA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -7636,11 +7807,10 @@ metricRight = "k_ssa-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "k_ssa_ra_iMatra-khoj";
 kernLeft = KSSA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -7966,11 +8136,10 @@ metricRight = "k_ssa_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "k_ssa_ra_iiMatra-khoj";
 kernLeft = KSSA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -8335,11 +8504,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "k_ssa_ra_uMatra-khoj";
 kernLeft = LU;
 kernRight = KHU;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -8690,11 +8858,1270 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
+glyphname = "qa-khoj";
+kernLeft = DA;
+kernRight = KA;
+lastChange = "2023-06-05 09:48:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (775,-99);
+},
+{
+name = nukta;
+pos = (479,536);
+},
+{
+name = rakar;
+pos = (685,30);
+},
+{
+name = top;
+pos = (684,516);
+}
+);
+guides = (
+{
+angle = 90;
+pos = (45,473);
+}
+);
+layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
+shapes = (
+{
+closed = 1;
+nodes = (
+(497,15,o),
+(670,214,o),
+(670,333,cs),
+(670,409,o),
+(606,509,o),
+(512,509,cs),
+(447,509,o),
+(400,453,o),
+(340,372,cs),
+(281,292,o),
+(244,237,o),
+(185,237,cs),
+(150,237,o),
+(125,256,o),
+(125,297,cs),
+(125,352,o),
+(169,405,o),
+(227,405,cs),
+(275,405,o),
+(291,347,o),
+(294,284,c),
+(333,316,l),
+(328,410,o),
+(283,486,o),
+(194,486,cs),
+(110,486,o),
+(45,415,o),
+(45,338,cs),
+(45,252,o),
+(128,166,o),
+(221,166,cs),
+(299,166,o),
+(344,226,o),
+(411,313,cs),
+(465,383,o),
+(503,433,o),
+(550,433,cs),
+(585,433,o),
+(610,405,o),
+(610,368,cs),
+(610,306,o),
+(542,234,o),
+(484,193,c),
+(412,170,o),
+(350,136,o),
+(350,95,cs),
+(350,60,o),
+(388,15,o),
+(423,15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(812,-145,o),
+(836,-127,o),
+(836,-95,cs),
+(836,-79,o),
+(830,-60,o),
+(817,-41,c),
+(792,-56,o),
+(755,-72,o),
+(730,-72,cs),
+(712,-72,o),
+(704,-62,o),
+(704,-47,cs),
+(704,-22,o),
+(727,22,o),
+(727,58,cs),
+(727,124,o),
+(647,183,o),
+(561,183,c),
+(552,116,l),
+(567,124,o),
+(582,129,o),
+(597,129,cs),
+(618,129,o),
+(634,119,o),
+(634,90,cs),
+(634,70,o),
+(627,21,o),
+(627,1,cs),
+(627,-70,o),
+(712,-145,o),
+(779,-145,cs)
+);
+}
+);
+width = 796;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (820,-126);
+},
+{
+name = nukta;
+pos = (508,540);
+},
+{
+name = rakar;
+pos = (737,26);
+},
+{
+name = top;
+pos = (749,516);
+}
+);
+layerId = "A430B39A-257A-41FC-BEA9-652C696FFEF7";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,-16,o),
+(722,182,o),
+(722,318,cs),
+(722,422,o),
+(637,528,o),
+(536,528,cs),
+(464,528,o),
+(415,490,o),
+(342,386,cs),
+(270,283,o),
+(236,244,o),
+(186,244,cs),
+(158,244,o),
+(142,262,o),
+(142,291,cs),
+(142,344,o),
+(191,392,o),
+(238,392,cs),
+(279,392,o),
+(296,355,o),
+(304,293,c),
+(360,338,l),
+(346,439,o),
+(300,511,o),
+(202,511,cs),
+(108,511,o),
+(30,435,o),
+(30,341,cs),
+(30,240,o),
+(127,145,o),
+(234,145,cs),
+(324,145,o),
+(383,214,o),
+(449,300,cs),
+(519,391,o),
+(555,418,o),
+(585,418,cs),
+(615,418,o),
+(631,394,o),
+(630,363,cs),
+(628,314,o),
+(570,240,o),
+(516,202,c),
+(444,179,o),
+(361,140,o),
+(361,84,cs),
+(361,37,o),
+(406,-16,o),
+(453,-16,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(869,-160,o),
+(895,-137,o),
+(895,-99,cs),
+(895,-75,o),
+(884,-52,o),
+(859,-30,c),
+(840,-46,o),
+(806,-65,o),
+(778,-65,cs),
+(767,-65,o),
+(762,-61,o),
+(762,-52,cs),
+(762,-33,o),
+(791,3,o),
+(791,50,cs),
+(791,110,o),
+(716,170,o),
+(629,182,c),
+(611,102,l),
+(623,111,o),
+(633,114,o),
+(643,114,cs),
+(655,114,o),
+(663,107,o),
+(663,91,cs),
+(663,66,o),
+(652,30,o),
+(652,-1,cs),
+(652,-74,o),
+(746,-160,o),
+(824,-160,cs)
+);
+}
+);
+width = 845;
+}
+);
+metricLeft = "ya-khoj";
+metricRight = "ka-khoj";
+note = kj_KA;
+script = khoj;
+unicode = 70207;
+},
+{
+glyphname = "qa_iMatra-khoj";
+kernLeft = DA;
+kernRight = HI;
+lastChange = "2023-06-05 09:48:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (715,-99);
+},
+{
+name = nukta;
+pos = (479,536);
+},
+{
+name = rakar;
+pos = (741,106);
+},
+{
+name = top;
+pos = (1164,892);
+}
+);
+layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
+shapes = (
+{
+closed = 1;
+nodes = (
+(751,-144,l),
+(776,-17,o),
+(822,192,o),
+(865,378,cs),
+(905,551,o),
+(930,678,o),
+(979,749,cs),
+(1009,792,o),
+(1046,814,o),
+(1101,814,cs),
+(1165,814,o),
+(1220,782,o),
+(1261,736,c),
+(1270,738,l),
+(1265,809,l),
+(1218,860,o),
+(1154,895,o),
+(1079,895,cs),
+(1005,895,o),
+(952,865,o),
+(913,814,cs),
+(854,737,o),
+(835,634,o),
+(799,462,cs),
+(723,104,l),
+(752,85,l),
+(732,139,o),
+(691,182,o),
+(598,182,cs),
+(594,182,o),
+(587,181,o),
+(584,181,c),
+(565,122,l),
+(581,128,o),
+(596,130,o),
+(611,130,cs),
+(666,130,o),
+(696,104,o),
+(696,43,cs),
+(696,10,o),
+(687,-37,o),
+(675,-99,c),
+(737,-146,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(497,15,o),
+(670,214,o),
+(670,333,cs),
+(670,409,o),
+(606,509,o),
+(512,509,cs),
+(447,509,o),
+(400,453,o),
+(340,372,cs),
+(281,292,o),
+(244,237,o),
+(185,237,cs),
+(150,237,o),
+(125,256,o),
+(125,297,cs),
+(125,352,o),
+(169,405,o),
+(227,405,cs),
+(275,405,o),
+(289,347,o),
+(291,284,c),
+(333,316,l),
+(328,410,o),
+(283,486,o),
+(194,486,cs),
+(110,486,o),
+(45,415,o),
+(45,338,cs),
+(45,252,o),
+(128,166,o),
+(221,166,cs),
+(299,166,o),
+(344,226,o),
+(411,313,cs),
+(465,383,o),
+(503,433,o),
+(550,433,cs),
+(585,433,o),
+(610,405,o),
+(610,368,cs),
+(610,306,o),
+(542,234,o),
+(484,193,c),
+(412,170,o),
+(350,136,o),
+(350,95,cs),
+(350,60,o),
+(388,15,o),
+(423,15,cs)
+);
+}
+);
+width = 980;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (770,-128);
+},
+{
+name = nukta;
+pos = (508,540);
+},
+{
+name = rakar;
+pos = (800,106);
+},
+{
+name = top;
+pos = (1257,918);
+}
+);
+layerId = "A430B39A-257A-41FC-BEA9-652C696FFEF7";
+shapes = (
+{
+closed = 1;
+nodes = (
+(823,-164,l),
+(856,1,o),
+(900,205,o),
+(937,376,cs),
+(970,529,o),
+(994,623,o),
+(1020,683,cs),
+(1050,753,o),
+(1100,801,o),
+(1184,801,cs),
+(1245,801,o),
+(1309,771,o),
+(1351,727,c),
+(1364,732,l),
+(1348,829,l),
+(1283,888,o),
+(1215,918,o),
+(1140,918,cs),
+(1041,918,o),
+(969,871,o),
+(922,782,cs),
+(884,710,o),
+(860,608,o),
+(833,477,cs),
+(758,119,l),
+(796,125,l),
+(761,169,o),
+(717,187,o),
+(664,187,cs),
+(650,187,o),
+(635,185,o),
+(620,181,c),
+(607,98,l),
+(621,107,o),
+(641,113,o),
+(661,113,cs),
+(694,113,o),
+(729,95,o),
+(729,43,cs),
+(729,10,o),
+(721,-39,o),
+(708,-108,c),
+(790,-169,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(545,-16,o),
+(722,182,o),
+(722,318,cs),
+(722,422,o),
+(637,528,o),
+(536,528,cs),
+(464,528,o),
+(415,490,o),
+(342,386,cs),
+(270,283,o),
+(236,244,o),
+(186,244,cs),
+(158,244,o),
+(142,262,o),
+(142,291,cs),
+(142,344,o),
+(191,392,o),
+(238,392,cs),
+(279,392,o),
+(296,355,o),
+(304,293,c),
+(360,338,l),
+(346,439,o),
+(300,511,o),
+(202,511,cs),
+(108,511,o),
+(30,435,o),
+(30,341,cs),
+(30,240,o),
+(127,145,o),
+(234,145,cs),
+(324,145,o),
+(383,214,o),
+(449,300,cs),
+(519,391,o),
+(555,418,o),
+(585,418,cs),
+(615,418,o),
+(631,394,o),
+(630,363,cs),
+(628,314,o),
+(570,240,o),
+(516,202,c),
+(444,179,o),
+(361,140,o),
+(361,84,cs),
+(361,37,o),
+(406,-16,o),
+(453,-16,cs)
+);
+}
+);
+width = 1057;
+}
+);
+metricLeft = "ya-khoj";
+metricRight = "ka_iMatra-khoj";
+script = khoj;
+},
+{
+category = Letter;
+glyphname = "qa_iiMatra-khoj";
+kernLeft = DA;
+kernRight = HII;
+lastChange = "2023-06-05 09:48:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (863,-99);
+},
+{
+name = nukta;
+pos = (480,536);
+},
+{
+name = rakar;
+pos = (742,116);
+},
+{
+name = top;
+pos = (1054,539);
+}
+);
+layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
+shapes = (
+{
+closed = 1;
+nodes = (
+(1180,-240,o),
+(1220,-223,o),
+(1221,-186,cs),
+(1222,-157,o),
+(1198,-133,o),
+(1167,-114,c),
+(1156,-139,o),
+(1123,-158,o),
+(1091,-158,cs),
+(1054,-158,o),
+(1039,-132,o),
+(1039,-66,cs),
+(1039,40,o),
+(1077,188,o),
+(1077,285,cs),
+(1077,411,o),
+(1018,544,o),
+(940,544,cs),
+(900,544,o),
+(862,509,o),
+(826,432,cs),
+(791,357,o),
+(756,246,o),
+(718,116,c),
+(753,96,l),
+(736,146,o),
+(689,193,o),
+(607,193,cs),
+(600,193,o),
+(593,193,o),
+(585,192,c),
+(566,133,l),
+(582,139,o),
+(597,141,o),
+(611,141,cs),
+(665,141,o),
+(698,117,o),
+(698,67,cs),
+(698,39,o),
+(690,-4,o),
+(675,-58,c),
+(732,-126,l),
+(749,-122,l),
+(767,-31,o),
+(804,133,o),
+(850,263,cs),
+(893,386,o),
+(931,463,o),
+(965,463,cs),
+(990,463,o),
+(999,410,o),
+(999,365,cs),
+(999,266,o),
+(957,87,o),
+(957,-4,cs),
+(957,-132,o),
+(1039,-240,o),
+(1140,-240,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(497,15,o),
+(670,214,o),
+(670,333,cs),
+(670,409,o),
+(606,509,o),
+(512,509,cs),
+(447,509,o),
+(400,453,o),
+(340,372,cs),
+(281,292,o),
+(244,237,o),
+(185,237,cs),
+(150,237,o),
+(125,256,o),
+(125,297,cs),
+(125,352,o),
+(169,405,o),
+(227,405,cs),
+(275,405,o),
+(291,347,o),
+(294,284,c),
+(333,316,l),
+(328,410,o),
+(283,486,o),
+(194,486,cs),
+(110,486,o),
+(45,415,o),
+(45,338,cs),
+(45,252,o),
+(128,166,o),
+(221,166,cs),
+(299,166,o),
+(344,226,o),
+(411,313,cs),
+(465,383,o),
+(503,433,o),
+(550,433,cs),
+(585,433,o),
+(610,405,o),
+(610,368,cs),
+(610,306,o),
+(542,234,o),
+(484,193,c),
+(412,170,o),
+(350,136,o),
+(350,95,cs),
+(350,60,o),
+(388,15,o),
+(423,15,cs)
+);
+}
+);
+width = 1151;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (891,-142);
+},
+{
+name = nukta;
+pos = (487,540);
+},
+{
+name = rakar;
+pos = (786,50);
+},
+{
+name = top;
+pos = (1099,568);
+}
+);
+layerId = "A430B39A-257A-41FC-BEA9-652C696FFEF7";
+shapes = (
+{
+closed = 1;
+nodes = (
+(1255,-262,o),
+(1299,-234,o),
+(1300,-189,cs),
+(1301,-152,o),
+(1274,-122,o),
+(1237,-101,c),
+(1215,-135,o),
+(1187,-157,o),
+(1153,-157,cs),
+(1121,-157,o),
+(1102,-136,o),
+(1102,-81,cs),
+(1102,31,o),
+(1139,180,o),
+(1139,279,cs),
+(1139,421,o),
+(1056,567,o),
+(972,567,cs),
+(922,567,o),
+(881,527,o),
+(843,441,cs),
+(809,365,o),
+(779,269,o),
+(743,145,c),
+(774,146,l),
+(751,183,o),
+(720,200,o),
+(673,200,cs),
+(660,200,o),
+(646,199,o),
+(631,196,c),
+(609,110,l),
+(625,117,o),
+(641,120,o),
+(657,120,cs),
+(699,120,o),
+(716,102,o),
+(716,60,cs),
+(716,31,o),
+(707,-12,o),
+(693,-65,c),
+(773,-155,l),
+(805,-150,l),
+(822,-62,o),
+(870,132,o),
+(910,256,cs),
+(953,388,o),
+(978,440,o),
+(1000,440,cs),
+(1011,440,o),
+(1020,421,o),
+(1020,380,cs),
+(1020,287,o),
+(983,110,o),
+(983,16,cs),
+(983,-128,o),
+(1074,-262,o),
+(1198,-262,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(545,-16,o),
+(722,182,o),
+(722,318,cs),
+(722,422,o),
+(637,528,o),
+(536,528,cs),
+(464,528,o),
+(415,490,o),
+(342,386,cs),
+(270,283,o),
+(236,244,o),
+(186,244,cs),
+(158,244,o),
+(142,262,o),
+(142,291,cs),
+(142,344,o),
+(191,392,o),
+(238,392,cs),
+(279,392,o),
+(296,355,o),
+(304,293,c),
+(360,338,l),
+(346,439,o),
+(300,511,o),
+(202,511,cs),
+(108,511,o),
+(30,435,o),
+(30,341,cs),
+(30,240,o),
+(127,145,o),
+(234,145,cs),
+(324,145,o),
+(383,214,o),
+(449,300,cs),
+(519,391,o),
+(555,418,o),
+(585,418,cs),
+(615,418,o),
+(631,394,o),
+(630,363,cs),
+(628,314,o),
+(570,240,o),
+(516,202,c),
+(444,179,o),
+(361,140,o),
+(361,84,cs),
+(361,37,o),
+(406,-16,o),
+(453,-16,cs)
+);
+}
+);
+width = 1214;
+}
+);
+metricLeft = "ya-khoj";
+metricRight = "ka_iiMatra-khoj";
+note = kj_KA;
+script = khoj;
+},
+{
+glyphname = "qa_uMatra-khoj";
+kernLeft = KU;
+kernRight = KA;
+lastChange = "2023-06-05 09:48:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (517,-179);
+},
+{
+name = nukta;
+pos = (453,536);
+},
+{
+name = top;
+pos = (658,516);
+}
+);
+layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,15,o),
+(693,214,o),
+(693,333,cs),
+(693,409,o),
+(629,509,o),
+(535,509,cs),
+(470,509,o),
+(423,453,o),
+(363,372,cs),
+(304,292,o),
+(267,237,o),
+(208,237,cs),
+(173,237,o),
+(148,256,o),
+(148,297,cs),
+(148,352,o),
+(192,405,o),
+(250,405,cs),
+(298,405,o),
+(314,347,o),
+(317,284,c),
+(356,316,l),
+(351,410,o),
+(306,486,o),
+(217,486,cs),
+(133,486,o),
+(68,415,o),
+(68,338,cs),
+(68,252,o),
+(151,166,o),
+(244,166,cs),
+(322,166,o),
+(367,226,o),
+(434,313,cs),
+(488,383,o),
+(526,433,o),
+(573,433,cs),
+(608,433,o),
+(633,405,o),
+(633,368,cs),
+(633,306,o),
+(565,234,o),
+(507,193,c),
+(435,170,o),
+(373,136,o),
+(373,95,cs),
+(373,60,o),
+(411,15,o),
+(446,15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(670,-191,o),
+(793,-111,o),
+(793,17,cs),
+(793,139,o),
+(681,201,o),
+(593,201,c),
+(580,129,l),
+(596,136,o),
+(612,140,o),
+(628,140,cs),
+(678,140,o),
+(720,110,o),
+(720,50,cs),
+(720,-45,o),
+(622,-108,o),
+(490,-108,cs),
+(327,-108,o),
+(169,-5,o),
+(60,146,c),
+(52,142,l),
+(45,86,l),
+(156,-76,o),
+(340,-191,o),
+(521,-191,cs)
+);
+}
+);
+width = 823;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (549,-210);
+},
+{
+name = nukta;
+pos = (518,540);
+},
+{
+name = top;
+pos = (709,516);
+}
+);
+layerId = "A430B39A-257A-41FC-BEA9-652C696FFEF7";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,-16,o),
+(736,182,o),
+(736,318,cs),
+(736,422,o),
+(651,528,o),
+(550,528,cs),
+(478,528,o),
+(429,490,o),
+(356,386,cs),
+(284,283,o),
+(250,244,o),
+(200,244,cs),
+(172,244,o),
+(156,262,o),
+(156,291,cs),
+(156,344,o),
+(205,392,o),
+(252,392,cs),
+(293,392,o),
+(310,355,o),
+(318,293,c),
+(374,338,l),
+(360,439,o),
+(314,511,o),
+(216,511,cs),
+(122,511,o),
+(44,435,o),
+(44,341,cs),
+(44,240,o),
+(141,145,o),
+(248,145,cs),
+(338,145,o),
+(397,214,o),
+(463,300,cs),
+(533,391,o),
+(569,418,o),
+(599,418,cs),
+(629,418,o),
+(645,394,o),
+(644,363,cs),
+(642,314,o),
+(584,240,o),
+(530,202,c),
+(458,179,o),
+(375,140,o),
+(375,84,cs),
+(375,37,o),
+(420,-16,o),
+(467,-16,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(737,-223,o),
+(843,-127,o),
+(843,3,cs),
+(843,122,o),
+(736,207,o),
+(605,209,c),
+(594,71,l),
+(619,93,o),
+(646,105,o),
+(680,105,cs),
+(713,105,o),
+(736,86,o),
+(736,47,cs),
+(736,-33,o),
+(643,-98,o),
+(505,-98,cs),
+(339,-98,o),
+(187,-16,o),
+(58,155,c),
+(44,153,l),
+(30,72,l),
+(154,-110,o),
+(340,-223,o),
+(549,-223,cs)
+);
+}
+);
+width = 858;
+}
+);
+metricRight = "ka_uMatra-khoj";
+script = khoj;
+},
+{
+category = Letter;
+glyphname = "q_ra_uMatra-khoj";
+kernLeft = KU;
+kernRight = KA;
+lastChange = "2023-06-05 09:48:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (570,-216);
+},
+{
+name = nukta;
+pos = (453,536);
+},
+{
+name = top;
+pos = (658,516);
+}
+);
+layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
+shapes = (
+{
+closed = 1;
+nodes = (
+(726,-228,o),
+(844,-148,o),
+(844,-3,cs),
+(844,117,o),
+(729,202,o),
+(594,202,c),
+(581,130,l),
+(602,135,o),
+(623,138,o),
+(642,138,cs),
+(714,138,o),
+(774,98,o),
+(774,25,cs),
+(774,-78,o),
+(679,-144,o),
+(543,-144,cs),
+(352,-144,o),
+(186,-22,o),
+(60,146,c),
+(52,142,l),
+(45,86,l),
+(171,-91,o),
+(360,-228,o),
+(574,-228,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(520,15,o),
+(693,214,o),
+(693,333,cs),
+(693,409,o),
+(629,509,o),
+(535,509,cs),
+(470,509,o),
+(423,453,o),
+(363,372,cs),
+(304,292,o),
+(267,237,o),
+(208,237,cs),
+(173,237,o),
+(148,256,o),
+(148,297,cs),
+(148,352,o),
+(192,405,o),
+(250,405,cs),
+(298,405,o),
+(314,347,o),
+(317,284,c),
+(356,316,l),
+(351,410,o),
+(306,486,o),
+(217,486,cs),
+(133,486,o),
+(68,415,o),
+(68,338,cs),
+(68,252,o),
+(151,166,o),
+(244,166,cs),
+(322,166,o),
+(367,226,o),
+(434,313,cs),
+(488,383,o),
+(526,433,o),
+(573,433,cs),
+(608,433,o),
+(633,405,o),
+(633,368,cs),
+(633,306,o),
+(565,234,o),
+(507,193,c),
+(435,170,o),
+(373,136,o),
+(373,95,cs),
+(373,60,o),
+(411,15,o),
+(447,15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(784,65,l),
+(735,124,l),
+(548,-13,l),
+(548,-20,l),
+(609,-73,l)
+);
+}
+);
+width = 874;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (590,-264);
+},
+{
+name = nukta;
+pos = (506,540);
+},
+{
+name = top;
+pos = (697,516);
+}
+);
+layerId = "A430B39A-257A-41FC-BEA9-652C696FFEF7";
+shapes = (
+{
+closed = 1;
+nodes = (
+(759,-277,o),
+(883,-187,o),
+(883,-38,cs),
+(883,92,o),
+(745,207,o),
+(602,209,c),
+(591,71,l),
+(616,93,o),
+(643,105,o),
+(677,105,cs),
+(730,105,o),
+(782,55,o),
+(782,14,cs),
+(782,-94,o),
+(684,-152,o),
+(554,-152,cs),
+(355,-152,o),
+(175,-33,o),
+(58,135,c),
+(44,133,l),
+(30,52,l),
+(147,-135,o),
+(366,-277,o),
+(590,-277,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(547,-16,o),
+(724,182,o),
+(724,318,cs),
+(724,422,o),
+(639,528,o),
+(538,528,cs),
+(466,528,o),
+(417,490,o),
+(344,386,cs),
+(272,283,o),
+(238,244,o),
+(188,244,cs),
+(160,244,o),
+(144,262,o),
+(144,291,cs),
+(144,344,o),
+(193,392,o),
+(240,392,cs),
+(281,392,o),
+(298,355,o),
+(306,293,c),
+(362,338,l),
+(348,439,o),
+(302,511,o),
+(204,511,cs),
+(110,511,o),
+(32,435,o),
+(32,341,cs),
+(32,240,o),
+(129,145,o),
+(236,145,cs),
+(326,145,o),
+(385,214,o),
+(451,300,cs),
+(521,391,o),
+(557,418,o),
+(587,418,cs),
+(617,418,o),
+(633,394,o),
+(632,363,cs),
+(630,314,o),
+(572,240,o),
+(518,202,c),
+(446,179,o),
+(363,140,o),
+(363,84,cs),
+(363,37,o),
+(408,-16,o),
+(455,-16,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(815,43,l),
+(751,118,l),
+(545,-33,l),
+(545,-50,l),
+(630,-107,l)
+);
+}
+);
+width = 898;
+}
+);
+metricLeft = "qa_uMatra-khoj";
+metricRight = "ka_uMatra-khoj";
+script = khoj;
+},
+{
+category = Letter;
 glyphname = "kha-khoj";
 kernLeft = A;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -8890,11 +10317,10 @@ unicode = 70153;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "kha_iMatra-khoj";
 kernLeft = A;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -9128,11 +10554,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "kha_iiMatra-khoj";
 kernLeft = A;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -9403,11 +10828,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "kha_uMatra-khoj";
 kernLeft = KU;
 kernRight = KHU;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -9645,11 +11069,10 @@ width = 911;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "kh_ra-khoj";
 kernLeft = A;
 kernRight = JA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -9869,11 +11292,10 @@ metricRight = "ja-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "kh_ra_iMatra-khoj";
 kernLeft = A;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -10125,11 +11547,10 @@ metricRight = "kha_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "kh_ra_iiMatra-khoj";
 kernLeft = A;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -10420,11 +11841,10 @@ script = khoj;
 },
 {
 category = "";
-color = 3;
 glyphname = "kh_ra_uMatra-khoj";
 kernLeft = KU;
 kernRight = KHU;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -10691,11 +12111,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ga-khoj";
 kernLeft = GA;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -10884,11 +12303,10 @@ script = khoj;
 unicode = 70154;
 },
 {
-color = 1;
 glyphname = "ga_iMatra-khoj";
 kernLeft = GA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -11114,11 +12532,10 @@ metricRight = "la_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "ga_iiMatra-khoj";
 kernLeft = GA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -11383,11 +12800,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ga_uMatra-khoj";
 kernLeft = YU;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -11589,11 +13005,10 @@ note = GU;
 script = khoj;
 },
 {
-color = 4;
 glyphname = "g_ra-khoj";
 kernLeft = GGA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -11645,11 +13060,10 @@ width = 681;
 script = khoj;
 },
 {
-color = 4;
 glyphname = "g_ra_iMatra-khoj";
 kernLeft = GGA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -11701,11 +13115,10 @@ width = 855;
 script = khoj;
 },
 {
-color = 4;
 glyphname = "g_ra_iiMatra-khoj";
 kernLeft = GGA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -11758,11 +13171,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 4;
 glyphname = "g_ra_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -11815,11 +13227,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "g_na-khoj";
 kernLeft = GGA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -12054,11 +13465,10 @@ note = JNYA;
 script = khoj;
 },
 {
-color = 1;
 glyphname = "g_na_iMatra-khoj";
 kernLeft = GGA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -12330,11 +13740,10 @@ metricRight = "gga_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "g_na_iiMatra-khoj";
 kernLeft = GGA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -12644,11 +14053,10 @@ metricRight = "gga_iiMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "g_na_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -12890,11 +14298,10 @@ metricRight = "gga_uMatra-khoj";
 script = khoj;
 },
 {
-color = 9;
 glyphname = "g_na_ra-khoj";
 kernLeft = GGA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -13168,11 +14575,10 @@ metricRight = "g_na-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "g_na_ra_iMatra-khoj";
 kernLeft = GGA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -13484,11 +14890,10 @@ metricRight = "g_na_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "g_na_ra_iiMatra-khoj";
 kernLeft = GGA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -13839,11 +15244,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "g_na_ra_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -14125,11 +15529,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "gga-khoj";
 kernLeft = GGA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -14318,11 +15721,10 @@ script = khoj;
 unicode = 70155;
 },
 {
-color = 1;
 glyphname = "gga_iMatra-khoj";
 kernLeft = GGA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -14548,11 +15950,10 @@ metricRight = "la_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "gga_iiMatra-khoj";
 kernLeft = GGA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -14816,11 +16217,10 @@ metricRight = "la_iiMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "gga_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -15015,11 +16415,10 @@ metricRight = "la-khoj";
 script = khoj;
 },
 {
-color = 9;
 glyphname = "gg_ra-khoj";
 kernLeft = GGA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -15223,11 +16622,10 @@ metricRight = "gga-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "gg_ra_iMatra-khoj";
 kernLeft = GGA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -15473,11 +16871,10 @@ metricRight = "gga_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "gg_ra_iiMatra-khoj";
 kernLeft = GGA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -15762,11 +17159,10 @@ script = khoj;
 },
 {
 category = "";
-color = 3;
 glyphname = "gg_ra_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -15983,11 +17379,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "gha-khoj";
 kernLeft = HA;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -16187,11 +17582,10 @@ script = khoj;
 unicode = 70156;
 },
 {
-color = 1;
 glyphname = "gha_iMatra-khoj";
 kernLeft = HA;
 kernRight = HI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -16423,11 +17817,10 @@ metricRight = "ja_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "gha_iiMatra-khoj";
 kernLeft = HA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -16696,11 +18089,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "gha_uMatra-khoj";
 kernLeft = HU;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -16900,11 +18292,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "nga-khoj";
 kernLeft = THREE;
 kernRight = DOTS;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -16977,11 +18368,10 @@ script = khoj;
 unicode = 70157;
 },
 {
-color = 1;
 glyphname = "nga_iMatra-khoj";
 kernLeft = THREE;
 kernRight = CHI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -17052,11 +18442,10 @@ metricLeft = "nga-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "nga_iiMatra-khoj";
 kernLeft = THREE;
 kernRight = II;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -17129,11 +18518,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "nga_uMatra-khoj";
 kernLeft = KU;
 kernRight = DOTS;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -17397,11 +18785,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ca-khoj";
 kernLeft = CA;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -17570,11 +18957,10 @@ script = khoj;
 unicode = 70158;
 },
 {
-color = 1;
 glyphname = "ca_iMatra-khoj";
 kernLeft = CA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -17780,11 +19166,10 @@ metricRight = "la_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "ca_iiMatra-khoj";
 kernLeft = CA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -18029,11 +19414,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ca_uMatra-khoj";
 kernLeft = YU;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -18215,11 +19599,10 @@ note = CU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "c_ra-khoj";
 kernLeft = CA;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -18407,11 +19790,10 @@ metricRight = "ca-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "c_ra_iMatra-khoj";
 kernLeft = CA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -18637,11 +20019,10 @@ metricRight = "ca_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "c_ra_iiMatra-khoj";
 kernLeft = CA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -18906,11 +20287,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "c_ra_uMatra-khoj";
 kernLeft = YU;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -19113,11 +20493,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "cha-khoj";
 kernLeft = LA;
 kernRight = CHA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -19302,11 +20681,10 @@ script = khoj;
 unicode = 70159;
 },
 {
-color = 1;
 glyphname = "cha_iMatra-khoj";
 kernLeft = LA;
 kernRight = CHI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -19537,11 +20915,10 @@ metricLeft = "cha-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "cha_iiMatra-khoj";
 kernLeft = LA;
 kernRight = CHII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -19811,11 +21188,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "cha_uMatra-khoj";
 kernLeft = KU;
 kernRight = KHU;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -20059,11 +21435,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ja-khoj";
 kernLeft = JA;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -20244,11 +21619,10 @@ unicode = 70160;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ja_iMatra-khoj";
 kernLeft = JA;
 kernRight = HI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -20464,11 +21838,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ja_iiMatra-khoj";
 kernLeft = JA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -20720,11 +22093,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ja_uMatra-khoj";
 kernLeft = LU;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -20913,11 +22285,10 @@ note = JU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "j_ra-khoj";
 kernLeft = JA;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -21117,11 +22488,10 @@ metricRight = "ja-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "j_ra_iMatra-khoj";
 kernLeft = JA;
 kernRight = HI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -21355,11 +22725,10 @@ metricRight = "ja_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "j_ra_iiMatra-khoj";
 kernLeft = JA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -21630,11 +22999,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "j_ra_uMatra-khoj";
 kernLeft = LU;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -21855,11 +23223,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "jja-khoj";
 kernLeft = PA;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -22049,11 +23416,10 @@ script = khoj;
 unicode = 70161;
 },
 {
-color = 1;
 glyphname = "jja_iMatra-khoj";
 kernLeft = PA;
 kernRight = CHI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -22283,11 +23649,10 @@ metricRight = "dha_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "jja_iiMatra-khoj";
 kernLeft = PA;
 kernRight = CHII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -22556,11 +23921,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "jja_uMatra-khoj";
 kernLeft = KU;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -22755,11 +24119,10 @@ metricRight = "a-khoj";
 script = khoj;
 },
 {
-color = 9;
 glyphname = "jj_ra-khoj";
 kernLeft = PA;
 kernRight = JA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -22967,11 +24330,10 @@ metricRight = "jja-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "jj_ra_iMatra-khoj";
 kernLeft = PA;
 kernRight = CHI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -23221,11 +24583,10 @@ metricRight = "jja_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "jj_ra_iiMatra-khoj";
 kernLeft = PA;
 kernRight = CHII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -23514,11 +24875,10 @@ script = khoj;
 },
 {
 category = "";
-color = 3;
 glyphname = "jj_ra_uMatra-khoj";
 kernLeft = KU;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -23735,11 +25095,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "nya-khoj";
 kernLeft = TWO;
 kernRight = DOTS;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -23813,11 +25172,10 @@ script = khoj;
 unicode = 70163;
 },
 {
-color = 1;
 glyphname = "nya_iMatra-khoj";
 kernLeft = TWO;
 kernRight = CHI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -23889,11 +25247,10 @@ metricRight = "nga_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "nya_iiMatra-khoj";
 kernLeft = TWO;
 kernRight = II;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -23966,11 +25323,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "nya_uMatra-khoj";
 kernLeft = KU;
 kernRight = DOTS;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -24244,11 +25600,10 @@ script = khoj;
 },
 {
 category = "";
-color = 3;
 glyphname = "ny_ra_uMatra-khoj";
 kernLeft = KU;
 kernRight = DOTS;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -24532,11 +25887,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "tta-khoj";
 kernLeft = HA;
 kernRight = TTA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -24660,11 +26014,10 @@ script = khoj;
 unicode = 70164;
 },
 {
-color = 1;
 glyphname = "tta_iMatra-khoj";
 kernLeft = HA;
 kernRight = CHI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -24829,11 +26182,10 @@ metricLeft = "tta-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "tta_iiMatra-khoj";
 kernLeft = HA;
 kernRight = CHII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -25037,11 +26389,10 @@ metricRight = "cha_iiMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "tta_uMatra-khoj";
 kernLeft = LU;
 kernRight = KHU;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -25209,11 +26560,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ttha-khoj";
 kernLeft = HA;
 kernRight = TTHA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -25347,11 +26697,10 @@ script = khoj;
 unicode = 70165;
 },
 {
-color = 1;
 glyphname = "ttha_iMatra-khoj";
 kernLeft = HA;
 kernRight = CHI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -25524,11 +26873,10 @@ metricLeft = "ttha-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "ttha_iiMatra-khoj";
 kernLeft = HA;
 kernRight = CHII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -25740,11 +27088,10 @@ metricRight = "tta_iiMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "ttha_uMatra-khoj";
 kernLeft = LU;
 kernRight = KHU;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -25921,11 +27268,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "dda-khoj";
 kernLeft = NNA;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -26207,11 +27553,10 @@ script = khoj;
 unicode = 70166;
 },
 {
-color = 1;
 glyphname = "dda_iMatra-khoj";
 kernLeft = NNA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -26524,11 +27869,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "dda_iiMatra-khoj";
 kernLeft = NNA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -26880,11 +28224,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "dda_uMatra-khoj";
 kernLeft = NNA;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -27173,11 +28516,10 @@ note = DDU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "dd_ra-khoj";
 kernLeft = NNA;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -27477,11 +28819,10 @@ metricRight = "dda-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "dd_ra_iMatra-khoj";
 kernLeft = NNA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -27813,11 +29154,10 @@ metricRight = "dda_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "dd_ra_iiMatra-khoj";
 kernLeft = NNA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -28188,11 +29528,10 @@ script = khoj;
 },
 {
 category = "";
-color = 3;
 glyphname = "dd_ra_uMatra-khoj";
 kernLeft = NNA;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -28495,11 +29834,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ddha-khoj";
 kernLeft = LA;
 kernRight = DDHA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -28680,11 +30018,10 @@ script = khoj;
 unicode = 70167;
 },
 {
-color = 1;
 glyphname = "ddha_iMatra-khoj";
 kernLeft = LA;
 kernRight = CHI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -28911,11 +30248,10 @@ metricLeft = "ddha-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "ddha_iiMatra-khoj";
 kernLeft = LA;
 kernRight = CHII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -29182,11 +30518,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ddha_uMatra-khoj";
 kernLeft = KU;
 kernRight = KHU;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -29404,11 +30739,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "nna-khoj";
 kernLeft = NNA;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -29646,11 +30980,10 @@ unicode = 70168;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "nna_iMatra-khoj";
 kernLeft = NNA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -29919,11 +31252,10 @@ note = kj_NNA;
 script = khoj;
 },
 {
-color = 1;
 glyphname = "nna_iiMatra-khoj";
 kernLeft = NNA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -30230,11 +31562,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "nna_uMatra-khoj";
 kernLeft = NNA;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -30479,11 +31810,10 @@ note = NNU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "nn_ra-khoj";
 kernLeft = NNA;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -30739,11 +32069,10 @@ metricRight = "nna-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "nn_ra_iMatra-khoj";
 kernLeft = NNA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -31031,11 +32360,10 @@ metricRight = "nna_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "nn_ra_iiMatra-khoj";
 kernLeft = NNA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -31362,11 +32690,10 @@ script = khoj;
 },
 {
 category = "";
-color = 3;
 glyphname = "nn_ra_uMatra-khoj";
 kernLeft = NNA;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -31631,11 +32958,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ta-khoj";
 kernLeft = KA;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -31806,11 +33132,10 @@ script = khoj;
 unicode = 70169;
 },
 {
-color = 1;
 glyphname = "ta_iMatra-khoj";
 kernLeft = KA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -32012,11 +33337,10 @@ metricRight = "nna_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "ta_iiMatra-khoj";
 kernLeft = KA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -32257,11 +33581,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ta_uMatra-khoj";
 kernLeft = LU;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -32440,11 +33763,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 9;
 glyphname = "t_ra-khoj";
 kernLeft = GA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -32598,11 +33920,10 @@ note = TRA;
 script = khoj;
 },
 {
-color = 3;
 glyphname = "t_ra_iMatra-khoj";
 kernLeft = GA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -32794,11 +34115,10 @@ metricRight = "la_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "t_ra_iiMatra-khoj";
 kernLeft = GA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -33029,11 +34349,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "t_ra_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -33196,11 +34515,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "tha-khoj";
 kernLeft = PA;
 kernRight = PA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -33426,11 +34744,10 @@ script = khoj;
 unicode = 70170;
 },
 {
-color = 1;
 glyphname = "tha_iMatra-khoj";
 kernLeft = PA;
 kernRight = DI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -33701,11 +35018,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "tha_iiMatra-khoj";
 kernLeft = PA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -33989,11 +35305,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "tha_uMatra-khoj";
 kernLeft = KU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -34214,11 +35529,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "da-khoj";
 kernLeft = DA;
 kernRight = KA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -34420,11 +35734,10 @@ unicode = 70171;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "da_iMatra-khoj";
 kernLeft = DA;
 kernRight = DI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -34671,11 +35984,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "da_iiMatra-khoj";
 kernLeft = DA;
 kernRight = HII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -34925,11 +36237,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "da_uMatra-khoj";
 kernLeft = YU;
 kernRight = KA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -35155,11 +36466,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 9;
 glyphname = "d_ra-khoj";
 kernLeft = HA;
 kernRight = KA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -35364,11 +36674,10 @@ note = DRA;
 script = khoj;
 },
 {
-color = 3;
 glyphname = "d_ra_iMatra-khoj";
 kernLeft = HA;
 kernRight = DRI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -35622,11 +36931,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "d_ra_iiMatra-khoj";
 kernLeft = HA;
 kernRight = CHII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -35919,11 +37227,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "d_ra_uMatra-khoj";
 kernLeft = HU;
 kernRight = KA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -36170,11 +37477,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ddda-khoj";
 kernLeft = HA;
 kernRight = HA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -36340,11 +37646,10 @@ unicode = 70172;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ddda_iMatra-khoj";
 kernLeft = DDDA;
 kernRight = DRI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -36551,11 +37856,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ddda_iiMatra-khoj";
 kernLeft = DDDA;
 kernRight = CHII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -36800,11 +38104,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ddda_uMatra-khoj";
 kernLeft = HU;
 kernRight = HA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -37013,11 +38316,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "dha-khoj";
 kernLeft = PA;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -37176,11 +38478,10 @@ script = khoj;
 unicode = 70173;
 },
 {
-color = 1;
 glyphname = "dha_iMatra-khoj";
 kernLeft = LA;
 kernRight = CHI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -37379,11 +38680,10 @@ metricLeft = "dha-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "dha_iiMatra-khoj";
 kernLeft = LA;
 kernRight = CHII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -37621,11 +38921,10 @@ metricRight = "cha_iiMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "dha_uMatra-khoj";
 kernLeft = KU;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -37790,11 +39089,10 @@ metricRight = "a-khoj";
 script = khoj;
 },
 {
-color = 9;
 glyphname = "dh_ra-khoj";
 kernLeft = LA;
 kernRight = JA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -37972,11 +39270,10 @@ metricRight = "nna-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "dh_ra_iMatra-khoj";
 kernLeft = LA;
 kernRight = CHI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -38196,11 +39493,10 @@ metricRight = "dha_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "dh_ra_iiMatra-khoj";
 kernLeft = LA;
 kernRight = CHII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -38459,11 +39755,10 @@ script = khoj;
 },
 {
 category = "";
-color = 3;
 glyphname = "dh_ra_uMatra-khoj";
 kernLeft = KU;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -38650,11 +39945,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "na-khoj";
 kernLeft = YA;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -38824,11 +40118,10 @@ script = khoj;
 unicode = 70174;
 },
 {
-color = 1;
 glyphname = "na_iMatra-khoj";
 kernLeft = YA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -39034,11 +40327,10 @@ metricRight = "la_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "na_iiMatra-khoj";
 kernLeft = YA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -39283,11 +40575,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "na_uMatra-khoj";
 kernLeft = YU;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -39463,11 +40754,10 @@ note = NU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "n_ra-khoj";
 kernLeft = YA;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -39659,11 +40949,10 @@ metricRight = "a-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "n_ra_iMatra-khoj";
 kernLeft = YA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -39887,11 +41176,10 @@ metricRight = "kh_ra_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "n_ra_iiMatra-khoj";
 kernLeft = YA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -40154,11 +41442,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "n_ra_uMatra-khoj";
 kernLeft = KU;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -40359,11 +41646,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "pa-khoj";
 kernLeft = PA;
 kernRight = PA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -40555,11 +41841,10 @@ script = khoj;
 unicode = 70175;
 },
 {
-color = 1;
 glyphname = "pa_iMatra-khoj";
 kernLeft = PA;
 kernRight = DI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -40797,11 +42082,10 @@ metricRight = "da_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "pa_iiMatra-khoj";
 kernLeft = PA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -41052,11 +42336,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "pa_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -41242,11 +42525,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "pha-khoj";
 kernLeft = PA;
 kernRight = KA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -41503,11 +42785,10 @@ unicode = 70176;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "pha_iMatra-khoj";
 kernLeft = PA;
 kernRight = DI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -41797,11 +43078,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "pha_iiMatra-khoj";
 kernLeft = PA;
 kernRight = HII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -42105,11 +43385,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "pha_uMatra-khoj";
 kernLeft = KU;
 kernRight = HA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -42380,11 +43659,10 @@ script = khoj;
 },
 {
 category = "";
-color = 3;
 glyphname = "ph_ra_uMatra-khoj";
 kernLeft = HU;
 kernRight = DA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -42666,11 +43944,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ba-khoj";
 kernLeft = A;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -42891,11 +44168,10 @@ script = khoj;
 unicode = 70177;
 },
 {
-color = 1;
 glyphname = "ba_iMatra-khoj";
 kernLeft = A;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -43147,11 +44423,10 @@ metricRight = "nna_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "ba_iiMatra-khoj";
 kernLeft = A;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -43442,11 +44717,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ba_uMatra-khoj";
 kernLeft = KU;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -43675,11 +44949,10 @@ note = BU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "b_ra-khoj";
 kernLeft = A;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -43919,11 +45192,10 @@ metricRight = "ba-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "b_ra_iMatra-khoj";
 kernLeft = A;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -44195,11 +45467,10 @@ metricRight = "ba_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "b_ra_iiMatra-khoj";
 kernLeft = A;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -44510,11 +45781,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "b_ra_uMatra-khoj";
 kernLeft = KU;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -44763,11 +46033,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "bba-khoj";
 kernLeft = GGA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -44958,11 +46227,10 @@ script = khoj;
 unicode = 70178;
 },
 {
-color = 1;
 glyphname = "bba_iMatra-khoj";
 kernLeft = GGA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -45190,11 +46458,10 @@ metricRight = "la_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "bba_iiMatra-khoj";
 kernLeft = GGA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -45461,11 +46728,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "bba_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -45664,11 +46930,10 @@ note = BBU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "bb_ra-khoj";
 kernLeft = GGA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -45878,11 +47143,10 @@ metricRight = "bba-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "bb_ra_iMatra-khoj";
 kernLeft = GGA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -46130,11 +47394,10 @@ metricRight = "bba_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "bb_ra_iiMatra-khoj";
 kernLeft = GGA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -46421,11 +47684,10 @@ script = khoj;
 },
 {
 category = "";
-color = 3;
 glyphname = "bb_ra_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -46644,11 +47906,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "bha-khoj";
 kernLeft = GA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -46837,11 +48098,10 @@ script = khoj;
 unicode = 70179;
 },
 {
-color = 1;
 glyphname = "bha_iMatra-khoj";
 kernLeft = GA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -47067,11 +48327,10 @@ metricRight = "la_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "bha_iiMatra-khoj";
 kernLeft = GA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -47336,11 +48595,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "bha_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -47537,11 +48795,10 @@ note = BHU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "bh_ra-khoj";
 kernLeft = GA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -47749,11 +49006,10 @@ metricRight = "bha-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "bh_ra_iMatra-khoj";
 kernLeft = GA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -47999,11 +49255,10 @@ metricRight = "bha_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "bh_ra_iiMatra-khoj";
 kernLeft = GA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -48288,11 +49543,10 @@ script = khoj;
 },
 {
 category = "";
-color = 3;
 glyphname = "bh_ra_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -48509,11 +49763,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ma-khoj";
 kernLeft = A;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -48713,11 +49966,10 @@ script = khoj;
 unicode = 70180;
 },
 {
-color = 1;
 glyphname = "ma_iMatra-khoj";
 kernLeft = A;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -48947,11 +50199,10 @@ metricRight = "nna_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "ma_iiMatra-khoj";
 kernLeft = A;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -49220,11 +50471,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ma_uMatra-khoj";
 kernLeft = KU;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -49430,11 +50680,10 @@ note = MU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "m_ra-khoj";
 kernLeft = A;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -49652,11 +50901,10 @@ metricRight = "ma-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "m_ra_iMatra-khoj";
 kernLeft = A;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -49906,11 +51154,10 @@ metricRight = "ma_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "m_ra_iiMatra-khoj";
 kernLeft = A;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -50199,11 +51446,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "m_ra_uMatra-khoj";
 kernLeft = KU;
 kernRight = NNA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -50430,11 +51676,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ya-khoj";
 kernLeft = YA;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -50680,11 +51925,10 @@ script = khoj;
 unicode = 70181;
 },
 {
-color = 1;
 glyphname = "ya_iMatra-khoj";
 kernLeft = YA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -50968,11 +52212,10 @@ metricRight = "la_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "ya_iiMatra-khoj";
 kernLeft = YA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -51295,11 +52538,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ya_uMatra-khoj";
 kernLeft = YU;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -51559,11 +52801,10 @@ note = YU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "y_ra-khoj";
 kernLeft = GGA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -51810,11 +53051,10 @@ metricRight = "aaMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "y_ra_iMatra-khoj";
 kernLeft = GGA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -52100,11 +53340,10 @@ metricRight = "la_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "y_ra_iiMatra-khoj";
 kernLeft = GGA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -52429,11 +53668,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "y_ra_uMatra-khoj";
 kernLeft = DA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -52690,11 +53928,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ra-khoj";
 kernLeft = NNA;
 kernRight = RA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -52878,11 +54115,10 @@ unicode = 70182;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ra_iMatra-khoj";
 kernLeft = NNA;
 kernRight = RI;
-lastChange = "2022-11-02 12:17:53 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -53089,11 +54325,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ra_iiMatra-khoj";
 kernLeft = NNA;
 kernRight = RII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -53338,11 +54573,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ra_uMatra-khoj";
 kernLeft = RU;
 kernRight = RA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -53539,11 +54773,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "la-khoj";
 kernLeft = LA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -53700,11 +54933,10 @@ script = khoj;
 unicode = 70183;
 },
 {
-color = 1;
 glyphname = "la_iMatra-khoj";
 kernLeft = LA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -53897,11 +55129,10 @@ metricLeft = "la-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "la_iiMatra-khoj";
 kernLeft = LA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -54134,11 +55365,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "la_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -54303,11 +55533,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 9;
 glyphname = "l_ra-khoj";
 kernLeft = LA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -54485,11 +55714,10 @@ subCategory = Other;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "l_ra_iMatra-khoj";
 kernLeft = LA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -54705,11 +55933,10 @@ subCategory = Other;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "l_ra_iiMatra-khoj";
 kernLeft = LA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -54963,11 +56190,10 @@ subCategory = Other;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "l_ra_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -55153,11 +56379,10 @@ subCategory = Other;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "va-khoj";
 kernLeft = YA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -55315,11 +56540,10 @@ script = khoj;
 unicode = 70184;
 },
 {
-color = 1;
 glyphname = "va_iMatra-khoj";
 kernLeft = YA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -55513,11 +56737,10 @@ metricRight = "la_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "va_iiMatra-khoj";
 kernLeft = YA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -55750,11 +56973,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "va_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -55918,11 +57140,10 @@ note = VU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "v_ra-khoj";
 kernLeft = GA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -56098,11 +57319,10 @@ metricRight = "va-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "v_ra_iMatra-khoj";
 kernLeft = GA;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -56316,11 +57536,10 @@ metricRight = "la_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "v_ra_iiMatra-khoj";
 kernLeft = GA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -56573,11 +57792,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "v_ra_uMatra-khoj";
 kernLeft = LU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -56762,11 +57980,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "sa-khoj";
 kernLeft = PA;
 kernRight = PA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -56833,11 +58050,10 @@ script = khoj;
 unicode = 70185;
 },
 {
-color = 1;
 glyphname = "sa_iMatra-khoj";
 kernLeft = PA;
 kernRight = DI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -56902,11 +58118,10 @@ metricRight = "pa_iMatra-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "sa_iiMatra-khoj";
 kernLeft = PA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -56972,11 +58187,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "sa_uMatra-khoj";
 kernLeft = SU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -57243,11 +58457,10 @@ note = SU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "s_ra-khoj";
 kernLeft = PA;
 kernRight = PA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -57525,11 +58738,10 @@ metricRight = "sa-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "s_ra_iMatra-khoj";
 kernLeft = PA;
 kernRight = DI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -57853,11 +59065,10 @@ metricRight = "sa_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "s_ra_iiMatra-khoj";
 kernLeft = PA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -58194,11 +59405,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "s_ra_uMatra-khoj";
 kernLeft = SU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -58472,11 +59682,10 @@ metricRight = "sa_uMatra-khoj";
 script = khoj;
 },
 {
-color = 0;
 glyphname = "sha-khoj";
 kernLeft = PA;
 kernRight = PA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -58536,11 +59745,10 @@ width = 975;
 script = khoj;
 },
 {
-color = 1;
 glyphname = "sha_iMatra-khoj";
 kernLeft = PA;
 kernRight = DI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -58600,11 +59808,10 @@ width = 1169;
 script = khoj;
 },
 {
-color = 1;
 glyphname = "sha_iiMatra-khoj";
 kernLeft = PA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -58664,11 +59871,10 @@ width = 1325;
 script = khoj;
 },
 {
-color = 1;
 glyphname = "sha_uMatra-khoj";
 kernLeft = SU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -58728,11 +59934,10 @@ width = 919;
 script = khoj;
 },
 {
-color = 1;
 glyphname = "sha_eMatra-khoj";
 kernLeft = PA;
 kernRight = PA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -58924,11 +60129,10 @@ metricRight = "sha-khoj";
 script = khoj;
 },
 {
-color = 9;
 glyphname = "sh_ra-khoj";
 kernLeft = PA;
 kernRight = PA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -58988,11 +60192,10 @@ width = 975;
 script = khoj;
 },
 {
-color = 3;
 glyphname = "sh_ra_iMatra-khoj";
 kernLeft = PA;
 kernRight = DI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -59052,11 +60255,10 @@ width = 1169;
 script = khoj;
 },
 {
-color = 3;
 glyphname = "sh_ra_iiMatra-khoj";
 kernLeft = PA;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -59117,11 +60319,10 @@ script = khoj;
 },
 {
 category = "";
-color = 3;
 glyphname = "sh_ra_uMatra-khoj";
 kernLeft = SU;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -59181,11 +60382,10 @@ width = 917;
 script = khoj;
 },
 {
-color = 3;
 glyphname = "sh_ra_eMatra-khoj";
 kernLeft = PA;
 kernRight = PA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -59378,11 +60578,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "ha-khoj";
 kernLeft = HA;
 kernRight = HA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -59556,11 +60755,10 @@ script = khoj;
 unicode = 70186;
 },
 {
-color = 1;
 glyphname = "ha_iMatra-khoj";
 kernLeft = HA;
 kernRight = HI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -59773,11 +60971,10 @@ metricLeft = "ha-khoj";
 script = khoj;
 },
 {
-color = 1;
 glyphname = "ha_iiMatra-khoj";
 kernLeft = HA;
 kernRight = HII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -60031,11 +61228,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "ha_uMatra-khoj";
 kernLeft = HU;
 kernRight = HA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -60254,11 +61450,10 @@ note = HU;
 script = khoj;
 },
 {
-color = 9;
 glyphname = "h_ra-khoj";
 kernLeft = HA;
 kernRight = HA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -60452,11 +61647,10 @@ metricRight = "ha-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "h_ra_iMatra-khoj";
 kernLeft = HA;
 kernRight = HI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -60690,11 +61884,10 @@ metricRight = "ha_iMatra-khoj";
 script = khoj;
 },
 {
-color = 3;
 glyphname = "h_ra_iiMatra-khoj";
 kernLeft = HA;
 kernRight = HII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -60959,11 +62152,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 3;
 glyphname = "h_ra_uMatra-khoj";
 kernLeft = HU;
 kernRight = HA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -61204,11 +62396,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 0;
 glyphname = "lla-khoj";
 kernLeft = CA;
 kernRight = HA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -61424,11 +62615,10 @@ script = khoj;
 unicode = 70187;
 },
 {
-color = 1;
 glyphname = "lla_iMatra-khoj";
 kernLeft = CA;
 kernRight = DI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -61693,11 +62883,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "lla_iiMatra-khoj";
 kernLeft = CA;
 kernRight = HII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -61992,11 +63181,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 1;
 glyphname = "lla_uMatra-khoj";
 kernLeft = KU;
 kernRight = KHU;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -62257,11 +63445,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 5;
 glyphname = "aaMatra-khoj";
 kernLeft = AA;
 kernRight = AA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -62350,13 +63537,13 @@ width = 295;
 );
 note = kj_vs_AA;
 script = khoj;
+subCategory = "Spacing Combining";
 unicode = 70188;
 },
 {
 category = Letter;
-color = 5;
 glyphname = "iMatra-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -62417,13 +63604,13 @@ width = 259;
 );
 note = kj_vs_I;
 script = khoj;
+subCategory = "Spacing Combining";
 unicode = 70189;
 },
 {
 category = Letter;
-color = 5;
 glyphname = "iiMatra-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -62530,13 +63717,13 @@ width = 314;
 );
 note = kj_vs_II;
 script = khoj;
+subCategory = "Spacing Combining";
 unicode = 70190;
 },
 {
 category = Mark;
-color = 5;
 glyphname = "uMatra-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -62638,9 +63825,8 @@ unicode = 70191;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "eMatra-khoj";
-lastChange = "2023-03-23 12:16:30 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -62718,9 +63904,8 @@ unicode = 70192;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "eMatra_anusvara-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -62770,9 +63955,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "eMatra_reph-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -62882,9 +64066,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "eMatra_reph_anusvara-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -62956,9 +64139,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "eMatra_shadda-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63004,9 +64186,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "Nukta_eMatra-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63054,9 +64235,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "Nukta_shadda_eMatra-khoj";
-lastChange = "2023-03-23 12:29:18 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63102,9 +64282,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 3;
 glyphname = "eMatra-khoj.alt";
-lastChange = "2023-03-23 12:16:42 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63187,9 +64366,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 3;
 glyphname = "eMatra_anusvara-khoj.alt";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63236,9 +64414,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 3;
 glyphname = "eMatra_reph-khoj.alt";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63348,9 +64525,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 3;
 glyphname = "eMatra_reph_anusvara-khoj.alt";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63422,9 +64598,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 3;
 glyphname = "eMatra_shadda-khoj.alt";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63472,9 +64647,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 3;
 glyphname = "Nukta_eMatra-khoj.alt";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63522,9 +64696,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 3;
 glyphname = "Nukta_shadda_eMatra-khoj.alt";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63572,9 +64745,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "aiMatra-khoj";
-lastChange = "2023-03-23 12:16:03 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63700,9 +64872,8 @@ unicode = 70193;
 },
 {
 category = "";
-color = 4;
 glyphname = "aiMatra_anusvara-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63748,9 +64919,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "aiMatra_reph-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63902,9 +65072,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "aiMatra_reph_anusvara-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -63976,9 +65145,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "aiMatra_shadda-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -64028,9 +65196,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "Nukta_aiMatra-khoj";
-lastChange = "2023-03-23 12:29:18 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -64080,9 +65247,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 4;
 glyphname = "Nukta_shadda_aiMatra-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -64128,9 +65294,8 @@ subCategory = Nonspacing;
 },
 {
 category = Letter;
-color = 5;
 glyphname = "oMatra-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64164,9 +65329,8 @@ script = khoj;
 unicode = 70194;
 },
 {
-color = 4;
 glyphname = "oMatra_anusvara-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64199,9 +65363,8 @@ script = khoj;
 },
 {
 category = Letter;
-color = 4;
 glyphname = "oMatra_reph-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64235,9 +65398,8 @@ subCategory = Other;
 },
 {
 category = Letter;
-color = 4;
 glyphname = "oMatra_reph_anusvara-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64270,9 +65432,8 @@ script = khoj;
 subCategory = Other;
 },
 {
-color = 4;
 glyphname = "oMatra_shadda-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64304,9 +65465,8 @@ width = 295;
 script = khoj;
 },
 {
-color = 4;
 glyphname = "Nukta_oMatra-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64338,9 +65498,8 @@ width = 295;
 script = khoj;
 },
 {
-color = 4;
 glyphname = "Nukta_shadda_oMatra-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64373,9 +65532,8 @@ script = khoj;
 },
 {
 category = Letter;
-color = 5;
 glyphname = "auMatra-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -64421,9 +65579,8 @@ script = khoj;
 unicode = 70195;
 },
 {
-color = 4;
 glyphname = "auMatra_anusvara-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64456,9 +65613,8 @@ script = khoj;
 },
 {
 category = Letter;
-color = 4;
 glyphname = "auMatra_reph-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64492,9 +65648,8 @@ subCategory = Other;
 },
 {
 category = Letter;
-color = 4;
 glyphname = "auMatra_reph_anusvara-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64527,9 +65682,8 @@ script = khoj;
 subCategory = Other;
 },
 {
-color = 4;
 glyphname = "auMatra_shadda-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64561,9 +65715,8 @@ width = 295;
 script = khoj;
 },
 {
-color = 4;
 glyphname = "Nukta_auMatra-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64595,9 +65748,8 @@ width = 295;
 script = khoj;
 },
 {
-color = 4;
 glyphname = "Nukta_shadda_auMatra-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -64630,9 +65782,8 @@ script = khoj;
 },
 {
 category = Mark;
-color = 10;
 glyphname = "reph-gujarati";
-lastChange = "2022-08-30 09:09:36 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -64715,9 +65866,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 10;
 glyphname = "reph_anusvara-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -64835,9 +65985,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 10;
 glyphname = "rakar-gujarati";
-lastChange = "2022-08-30 09:09:49 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -64892,9 +66041,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 10;
 glyphname = rakar.alt;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -64946,9 +66094,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 10;
 glyphname = rakar_umatra;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -65073,9 +66220,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 10;
 glyphname = rakar_rVocalicMatra;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -65190,11 +66336,10 @@ subCategory = Nonspacing;
 },
 {
 category = Letter;
-color = 8;
 glyphname = "yakar-khoj";
 kernLeft = YA.alt;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -65373,11 +66518,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 8;
 glyphname = "yakar_iMatra-khoj";
 kernLeft = YA.alt;
 kernRight = LI;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -65595,11 +66739,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 8;
 glyphname = "yakar_iiMatra-khoj";
 kernLeft = YA.alt;
 kernRight = LII;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -65855,11 +66998,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 8;
 glyphname = "yakar_uMatra-khoj";
 kernLeft = YU;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -66038,11 +67180,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 9;
 glyphname = "yakar_uMatra-khoj.alt";
 kernLeft = YU.alt;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -66227,11 +67368,10 @@ script = khoj;
 },
 {
 category = Letter;
-color = 9;
 glyphname = "yakar_uMatra-khoj.alt2";
 kernLeft = YU.alt;
 kernRight = YA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -66416,9 +67556,8 @@ script = khoj;
 },
 {
 category = Mark;
-color = 6;
 glyphname = "halant-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -66486,9 +67625,8 @@ unicode = 70197;
 },
 {
 category = Letter;
-color = 6;
 glyphname = "halant-khoj.alt";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -66555,10 +67693,9 @@ subCategory = Other;
 },
 {
 category = Mark;
-color = 7;
 glyphname = "Anusvara-khoj";
 kernRight = ANUSVARA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -66626,10 +67763,9 @@ unicode = 70196;
 },
 {
 category = Mark;
-color = 7;
 glyphname = "Anusvara-khoj.alt";
 kernRight = ANUSVARA;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -66730,9 +67866,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 7;
 glyphname = "Nukta-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -66868,9 +68003,8 @@ unicode = 70198;
 },
 {
 category = Mark;
-color = 7;
 glyphname = "Shadda-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -66974,9 +68108,8 @@ unicode = 70199;
 },
 {
 category = Mark;
-color = 7;
 glyphname = "Sukun-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -67064,9 +68197,8 @@ unicode = 70206;
 },
 {
 category = Mark;
-color = 7;
 glyphname = "Nukta_shadda-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -67114,9 +68246,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 7;
 glyphname = "Nukta_sukun-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -67164,9 +68295,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 7;
 glyphname = "Shadda_sukun-khoj";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -67214,9 +68344,8 @@ subCategory = Nonspacing;
 },
 {
 category = Mark;
-color = 7;
 glyphname = "Nukta-khoj.alt";
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -67259,11 +68388,11 @@ subCategory = Nonspacing;
 },
 {
 glyphname = rightWhiteIndex;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 backgroundImage = {
-imagePath = "../../../Desktop/T Y P E/TYPEFACE Design/G O O G L E/Khojki Serif/–Khojki SERIF/CASE STUDY/05. Sindhi Paheli IQBAL (Harvard)/Index.png";
+imagePath = "../../T Y P E/TYPEFACE Design/G O O G L E/Khojki Serif/–Khojki SERIF/CASE STUDY/05. Sindhi Paheli IQBAL (Harvard)/Index.png";
 pos = (830,-52);
 scale = (8.4786,8.7567);
 };
@@ -67639,7 +68768,7 @@ width = 1039;
 },
 {
 backgroundImage = {
-imagePath = "../../../Desktop/T Y P E/TYPEFACE Design/G O O G L E/Khojki Serif/–Khojki SERIF/CASE STUDY/05. Sindhi Paheli IQBAL (Harvard)/Index.png";
+imagePath = "../../T Y P E/TYPEFACE Design/G O O G L E/Khojki Serif/–Khojki SERIF/CASE STUDY/05. Sindhi Paheli IQBAL (Harvard)/Index.png";
 pos = (830,-52);
 scale = (8.4786,8.7567);
 };
@@ -68017,11 +69146,10 @@ width = 1039;
 unicode = 9758;
 },
 {
-color = 11;
 glyphname = wordseparator;
 kernLeft = DOTS;
 kernRight = DOTS;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -68120,9 +69248,8 @@ note = u1123A;
 unicode = 70202;
 },
 {
-color = 11;
 glyphname = abbreviation;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68209,11 +69336,10 @@ note = u1123D;
 unicode = 70205;
 },
 {
-color = 11;
 glyphname = danda;
 kernLeft = danda;
 kernRight = danda;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68314,11 +69440,10 @@ note = u11238;
 unicode = 70200;
 },
 {
-color = 11;
 glyphname = dbldanda;
 kernLeft = danda;
 kernRight = danda;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68353,9 +69478,8 @@ note = u11239;
 unicode = 70201;
 },
 {
-color = 11;
 glyphname = sectionmark;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68422,11 +69546,10 @@ note = u1123B;
 unicode = 70203;
 },
 {
-color = 11;
 glyphname = dblsectionmark;
 kernLeft = dblsectionmark;
 kernRight = dblsectionmark;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68463,9 +69586,8 @@ note = u1123C;
 unicode = 70204;
 },
 {
-color = 11;
 glyphname = sectionmark.alt;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68503,11 +69625,10 @@ width = 974;
 note = u1123B;
 },
 {
-color = 11;
 glyphname = dblsectionmark.alt;
 kernLeft = dblsectionmark;
 kernRight = dblsectionmark;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68548,9 +69669,8 @@ note = u1123C;
 },
 {
 category = Letter;
-color = 10;
 glyphname = fractionOneQuarter;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68588,9 +69708,8 @@ unicode = 43056;
 },
 {
 category = Letter;
-color = 10;
 glyphname = fractionOneHalf;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68625,9 +69744,8 @@ unicode = 43057;
 },
 {
 category = Letter;
-color = 10;
 glyphname = fractionThreeQuarters;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68672,9 +69790,8 @@ unicode = 43058;
 },
 {
 category = Letter;
-color = 10;
 glyphname = fractionOneSixteenth;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68712,9 +69829,8 @@ unicode = 43059;
 },
 {
 category = Letter;
-color = 10;
 glyphname = fractionOneEighth;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68752,9 +69868,8 @@ unicode = 43060;
 },
 {
 category = Letter;
-color = 10;
 glyphname = fractionThreeSixteenths;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68800,9 +69915,8 @@ unicode = 43061;
 },
 {
 category = Letter;
-color = 10;
 glyphname = quarterMark;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68890,9 +70004,8 @@ unicode = 43062;
 },
 {
 category = Letter;
-color = 10;
 glyphname = placeholderMark;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -68988,9 +70101,8 @@ unicode = 43063;
 },
 {
 category = Letter;
-color = 10;
 glyphname = rupeeMark;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -69062,9 +70174,8 @@ unicode = 43064;
 },
 {
 category = Letter;
-color = 10;
 glyphname = quantityMark;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -69149,7 +70260,7 @@ unicode = 43065;
 {
 export = 0;
 glyphname = i_v_dots;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -69278,7 +70389,7 @@ width = 508;
 {
 export = 0;
 glyphname = ii_v_dots;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -69445,7 +70556,7 @@ width = 692;
 {
 export = 0;
 glyphname = S_stroke;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -69559,7 +70670,7 @@ width = 482;
 {
 category = Mark;
 glyphname = NullMark;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -69570,788 +70681,10 @@ layerId = "A430B39A-257A-41FC-BEA9-652C696FFEF7";
 width = 0;
 }
 );
-},
-{
-category = Letter;
-color = 3;
-glyphname = "q_ra_uMatra-khoj";
-kernLeft = KU;
-kernRight = KA;
-lastChange = "2023-03-23 12:33:59 +0000";
-layers = (
-{
-anchors = (
-{
-name = bottom;
-pos = (571,-225);
-},
-{
-name = nukta;
-pos = (455,536);
-},
-{
-name = top;
-pos = (660,516);
-}
-);
-layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
-shapes = (
-{
-closed = 1;
-nodes = (
-(726,-228,o),
-(844,-148,o),
-(844,-3,cs),
-(844,117,o),
-(729,202,o),
-(594,202,c),
-(581,130,l),
-(602,135,o),
-(623,138,o),
-(642,138,cs),
-(714,138,o),
-(774,98,o),
-(774,25,cs),
-(774,-78,o),
-(679,-144,o),
-(543,-144,cs),
-(352,-144,o),
-(186,-22,o),
-(60,146,c),
-(52,142,l),
-(45,86,l),
-(171,-91,o),
-(360,-228,o),
-(574,-228,cs)
-);
-},
-{
-closed = 1;
-nodes = (
-(520,15,o),
-(693,214,o),
-(693,333,cs),
-(693,409,o),
-(629,509,o),
-(535,509,cs),
-(470,509,o),
-(423,453,o),
-(363,372,cs),
-(304,292,o),
-(267,237,o),
-(208,237,cs),
-(173,237,o),
-(148,256,o),
-(148,297,cs),
-(148,352,o),
-(192,405,o),
-(250,405,cs),
-(298,405,o),
-(314,347,o),
-(317,284,c),
-(356,316,l),
-(351,410,o),
-(306,486,o),
-(217,486,cs),
-(133,486,o),
-(68,415,o),
-(68,338,cs),
-(68,252,o),
-(151,166,o),
-(244,166,cs),
-(322,166,o),
-(367,226,o),
-(434,313,cs),
-(488,383,o),
-(526,433,o),
-(573,433,cs),
-(608,433,o),
-(633,405,o),
-(633,368,cs),
-(633,306,o),
-(565,234,o),
-(507,193,c),
-(435,170,o),
-(373,136,o),
-(373,95,cs),
-(373,60,o),
-(411,15,o),
-(447,15,cs)
-);
-},
-{
-closed = 1;
-nodes = (
-(784,65,l),
-(735,124,l),
-(548,-13,l),
-(548,-20,l),
-(609,-73,l)
-);
-}
-);
-width = 874;
-},
-{
-anchors = (
-{
-name = bottom;
-pos = (593,-264);
-},
-{
-name = nukta;
-pos = (465,536);
-},
-{
-name = top;
-pos = (670,516);
-}
-);
-layerId = "A430B39A-257A-41FC-BEA9-652C696FFEF7";
-shapes = (
-{
-closed = 1;
-nodes = (
-(767,-277,o),
-(891,-187,o),
-(891,-38,cs),
-(891,92,o),
-(753,207,o),
-(610,209,c),
-(599,71,l),
-(624,93,o),
-(651,105,o),
-(685,105,cs),
-(738,105,o),
-(790,55,o),
-(790,14,cs),
-(790,-94,o),
-(692,-152,o),
-(562,-152,cs),
-(363,-152,o),
-(184,-33,o),
-(67,136,c),
-(53,135,l),
-(30,56,l),
-(149,-133,o),
-(371,-277,o),
-(598,-277,cs)
-);
-},
-{
-closed = 1;
-nodes = (
-(555,-16,o),
-(732,182,o),
-(732,318,cs),
-(732,422,o),
-(647,528,o),
-(546,528,cs),
-(474,528,o),
-(425,490,o),
-(352,386,cs),
-(280,283,o),
-(246,244,o),
-(196,244,cs),
-(168,244,o),
-(152,262,o),
-(152,291,cs),
-(152,344,o),
-(201,392,o),
-(248,392,cs),
-(289,392,o),
-(306,355,o),
-(314,293,c),
-(370,338,l),
-(356,439,o),
-(310,511,o),
-(212,511,cs),
-(118,511,o),
-(40,435,o),
-(40,341,cs),
-(40,240,o),
-(137,145,o),
-(244,145,cs),
-(334,145,o),
-(393,214,o),
-(459,300,cs),
-(529,391,o),
-(565,418,o),
-(595,418,cs),
-(625,418,o),
-(641,394,o),
-(640,363,cs),
-(638,314,o),
-(580,240,o),
-(526,202,c),
-(454,179,o),
-(371,140,o),
-(371,84,cs),
-(371,37,o),
-(416,-16,o),
-(463,-16,cs)
-);
-},
-{
-closed = 1;
-nodes = (
-(823,43,l),
-(759,118,l),
-(553,-33,l),
-(553,-50,l),
-(638,-107,l)
-);
-}
-);
-width = 906;
-}
-);
-metricLeft = "ka_uMatra-khoj.alt";
-metricRight = "ka_uMatra-khoj";
-script = khoj;
-},
-{
-category = Letter;
-color = 0;
-glyphname = "qa-khoj";
-kernLeft = DA;
-kernRight = KA;
-lastChange = "2023-03-23 12:30:38 +0000";
-layers = (
-{
-anchors = (
-{
-name = bottom;
-pos = (775,-99);
-},
-{
-name = nukta;
-pos = (479,536);
-},
-{
-name = rakar;
-pos = (685,30);
-},
-{
-name = top;
-pos = (684,516);
-}
-);
-layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
-shapes = (
-{
-closed = 1;
-nodes = (
-(497,15,o),
-(670,214,o),
-(670,333,cs),
-(670,409,o),
-(606,509,o),
-(512,509,cs),
-(447,509,o),
-(400,453,o),
-(340,372,cs),
-(281,292,o),
-(244,237,o),
-(185,237,cs),
-(150,237,o),
-(125,256,o),
-(125,297,cs),
-(125,352,o),
-(169,405,o),
-(227,405,cs),
-(275,405,o),
-(291,347,o),
-(294,284,c),
-(333,316,l),
-(328,410,o),
-(283,486,o),
-(194,486,cs),
-(110,486,o),
-(45,415,o),
-(45,338,cs),
-(45,252,o),
-(128,166,o),
-(221,166,cs),
-(299,166,o),
-(344,226,o),
-(411,313,cs),
-(465,383,o),
-(503,433,o),
-(550,433,cs),
-(585,433,o),
-(610,405,o),
-(610,368,cs),
-(610,306,o),
-(542,234,o),
-(484,193,c),
-(412,170,o),
-(350,136,o),
-(350,95,cs),
-(350,60,o),
-(388,15,o),
-(423,15,cs)
-);
-},
-{
-closed = 1;
-nodes = (
-(812,-145,o),
-(836,-127,o),
-(836,-95,cs),
-(836,-79,o),
-(830,-60,o),
-(817,-41,c),
-(792,-56,o),
-(755,-72,o),
-(730,-72,cs),
-(712,-72,o),
-(704,-62,o),
-(704,-47,cs),
-(704,-22,o),
-(727,22,o),
-(727,58,cs),
-(727,124,o),
-(647,183,o),
-(561,183,c),
-(552,116,l),
-(567,124,o),
-(582,129,o),
-(597,129,cs),
-(618,129,o),
-(634,119,o),
-(634,90,cs),
-(634,70,o),
-(627,21,o),
-(627,1,cs),
-(627,-70,o),
-(712,-145,o),
-(779,-145,cs)
-);
-}
-);
-width = 796;
-},
-{
-anchors = (
-{
-name = bottom;
-pos = (820,-126);
-},
-{
-name = nukta;
-pos = (508,540);
-},
-{
-name = rakar;
-pos = (737,26);
-},
-{
-name = top;
-pos = (749,516);
-}
-);
-layerId = "A430B39A-257A-41FC-BEA9-652C696FFEF7";
-shapes = (
-{
-closed = 1;
-nodes = (
-(545,-16,o),
-(722,182,o),
-(722,318,cs),
-(722,422,o),
-(637,528,o),
-(536,528,cs),
-(464,528,o),
-(415,490,o),
-(342,386,cs),
-(270,283,o),
-(236,244,o),
-(186,244,cs),
-(158,244,o),
-(142,262,o),
-(142,291,cs),
-(142,344,o),
-(191,392,o),
-(238,392,cs),
-(279,392,o),
-(296,355,o),
-(304,293,c),
-(360,338,l),
-(346,439,o),
-(300,511,o),
-(202,511,cs),
-(108,511,o),
-(30,435,o),
-(30,341,cs),
-(30,240,o),
-(127,145,o),
-(234,145,cs),
-(324,145,o),
-(383,214,o),
-(449,300,cs),
-(519,391,o),
-(555,418,o),
-(585,418,cs),
-(615,418,o),
-(631,394,o),
-(630,363,cs),
-(628,314,o),
-(570,240,o),
-(516,202,c),
-(444,179,o),
-(361,140,o),
-(361,84,cs),
-(361,37,o),
-(406,-16,o),
-(453,-16,cs)
-);
-},
-{
-closed = 1;
-nodes = (
-(869,-160,o),
-(895,-137,o),
-(895,-99,cs),
-(895,-75,o),
-(884,-52,o),
-(859,-30,c),
-(840,-46,o),
-(806,-65,o),
-(778,-65,cs),
-(767,-65,o),
-(762,-61,o),
-(762,-52,cs),
-(762,-33,o),
-(791,3,o),
-(791,50,cs),
-(791,110,o),
-(716,170,o),
-(629,182,c),
-(611,102,l),
-(623,111,o),
-(633,114,o),
-(643,114,cs),
-(655,114,o),
-(663,107,o),
-(663,91,cs),
-(663,66,o),
-(652,30,o),
-(652,-1,cs),
-(652,-74,o),
-(746,-160,o),
-(824,-160,cs)
-);
-}
-);
-width = 845;
-}
-);
-metricLeft = "ya-khoj";
-metricRight = "ka-khoj";
-note = kj_KA;
-script = khoj;
-unicode = 70207;
-},
-{
-category = Letter;
-color = 1;
-glyphname = "qa_iiMatra-khoj";
-kernLeft = DA;
-kernRight = HII;
-lastChange = "2023-03-23 12:33:11 +0000";
-layers = (
-{
-anchors = (
-{
-name = bottom;
-pos = (863,-99);
-},
-{
-name = nukta;
-pos = (480,536);
-},
-{
-name = rakar;
-pos = (742,116);
-},
-{
-name = top;
-pos = (1054,539);
-}
-);
-layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
-shapes = (
-{
-closed = 1;
-nodes = (
-(1180,-240,o),
-(1220,-223,o),
-(1221,-186,cs),
-(1222,-157,o),
-(1198,-133,o),
-(1167,-114,c),
-(1156,-139,o),
-(1123,-158,o),
-(1091,-158,cs),
-(1054,-158,o),
-(1039,-132,o),
-(1039,-66,cs),
-(1039,40,o),
-(1077,188,o),
-(1077,285,cs),
-(1077,411,o),
-(1018,544,o),
-(940,544,cs),
-(900,544,o),
-(862,509,o),
-(826,432,cs),
-(791,357,o),
-(756,246,o),
-(718,116,c),
-(753,96,l),
-(736,146,o),
-(689,193,o),
-(607,193,cs),
-(600,193,o),
-(593,193,o),
-(585,192,c),
-(566,133,l),
-(582,139,o),
-(597,141,o),
-(611,141,cs),
-(665,141,o),
-(698,117,o),
-(698,67,cs),
-(698,39,o),
-(690,-4,o),
-(675,-58,c),
-(732,-126,l),
-(749,-122,l),
-(767,-31,o),
-(804,133,o),
-(850,263,cs),
-(893,386,o),
-(931,463,o),
-(965,463,cs),
-(990,463,o),
-(999,410,o),
-(999,365,cs),
-(999,266,o),
-(957,87,o),
-(957,-4,cs),
-(957,-132,o),
-(1039,-240,o),
-(1140,-240,cs)
-);
-},
-{
-closed = 1;
-nodes = (
-(497,15,o),
-(670,214,o),
-(670,333,cs),
-(670,409,o),
-(606,509,o),
-(512,509,cs),
-(447,509,o),
-(400,453,o),
-(340,372,cs),
-(281,292,o),
-(244,237,o),
-(185,237,cs),
-(150,237,o),
-(125,256,o),
-(125,297,cs),
-(125,352,o),
-(169,405,o),
-(227,405,cs),
-(275,405,o),
-(291,347,o),
-(294,284,c),
-(333,316,l),
-(328,410,o),
-(283,486,o),
-(194,486,cs),
-(110,486,o),
-(45,415,o),
-(45,338,cs),
-(45,252,o),
-(128,166,o),
-(221,166,cs),
-(299,166,o),
-(344,226,o),
-(411,313,cs),
-(465,383,o),
-(503,433,o),
-(550,433,cs),
-(585,433,o),
-(610,405,o),
-(610,368,cs),
-(610,306,o),
-(542,234,o),
-(484,193,c),
-(412,170,o),
-(350,136,o),
-(350,95,cs),
-(350,60,o),
-(388,15,o),
-(423,15,cs)
-);
-}
-);
-width = 1151;
-},
-{
-anchors = (
-{
-name = bottom;
-pos = (891,-142);
-},
-{
-name = nukta;
-pos = (487,540);
-},
-{
-name = rakar;
-pos = (786,50);
-},
-{
-name = top;
-pos = (1099,568);
-}
-);
-layerId = "A430B39A-257A-41FC-BEA9-652C696FFEF7";
-shapes = (
-{
-closed = 1;
-nodes = (
-(1255,-262,o),
-(1299,-234,o),
-(1300,-189,cs),
-(1301,-152,o),
-(1274,-122,o),
-(1237,-101,c),
-(1215,-135,o),
-(1187,-157,o),
-(1153,-157,cs),
-(1121,-157,o),
-(1102,-136,o),
-(1102,-81,cs),
-(1102,31,o),
-(1139,180,o),
-(1139,279,cs),
-(1139,421,o),
-(1056,567,o),
-(972,567,cs),
-(922,567,o),
-(881,527,o),
-(843,441,cs),
-(809,365,o),
-(779,269,o),
-(743,145,c),
-(774,146,l),
-(751,183,o),
-(720,200,o),
-(673,200,cs),
-(660,200,o),
-(646,199,o),
-(631,196,c),
-(609,110,l),
-(625,117,o),
-(641,120,o),
-(657,120,cs),
-(699,120,o),
-(716,102,o),
-(716,60,cs),
-(716,31,o),
-(707,-12,o),
-(693,-65,c),
-(773,-155,l),
-(805,-150,l),
-(822,-62,o),
-(870,132,o),
-(910,256,cs),
-(953,388,o),
-(978,440,o),
-(1000,440,cs),
-(1011,440,o),
-(1020,421,o),
-(1020,380,cs),
-(1020,287,o),
-(983,110,o),
-(983,16,cs),
-(983,-128,o),
-(1074,-262,o),
-(1198,-262,cs)
-);
-},
-{
-closed = 1;
-nodes = (
-(545,-16,o),
-(722,182,o),
-(722,318,cs),
-(722,422,o),
-(637,528,o),
-(536,528,cs),
-(464,528,o),
-(415,490,o),
-(342,386,cs),
-(270,283,o),
-(236,244,o),
-(186,244,cs),
-(158,244,o),
-(142,262,o),
-(142,291,cs),
-(142,344,o),
-(191,392,o),
-(238,392,cs),
-(279,392,o),
-(296,355,o),
-(304,293,c),
-(360,338,l),
-(346,439,o),
-(300,511,o),
-(202,511,cs),
-(108,511,o),
-(30,435,o),
-(30,341,cs),
-(30,240,o),
-(127,145,o),
-(234,145,cs),
-(324,145,o),
-(383,214,o),
-(449,300,cs),
-(519,391,o),
-(555,418,o),
-(585,418,cs),
-(615,418,o),
-(631,394,o),
-(630,363,cs),
-(628,314,o),
-(570,240,o),
-(516,202,c),
-(444,179,o),
-(361,140,o),
-(361,84,cs),
-(361,37,o),
-(406,-16,o),
-(453,-16,cs)
-);
-}
-);
-width = 1214;
-}
-);
-metricLeft = "ka-khoj.alt";
-metricRight = "ka_iiMatra-khoj";
-note = kj_KA;
-script = khoj;
 },
 {
 glyphname = zero;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -70438,7 +70771,7 @@ unicode = 48;
 },
 {
 glyphname = one;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -70515,7 +70848,7 @@ unicode = 49;
 },
 {
 glyphname = two;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -70608,7 +70941,7 @@ unicode = 50;
 },
 {
 glyphname = three;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -70727,7 +71060,7 @@ unicode = 51;
 },
 {
 glyphname = four;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -70826,7 +71159,7 @@ unicode = 52;
 },
 {
 glyphname = five;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -70931,7 +71264,7 @@ unicode = 53;
 },
 {
 glyphname = six;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -71048,7 +71381,7 @@ unicode = 54;
 },
 {
 glyphname = seven;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -71101,7 +71434,7 @@ unicode = 55;
 },
 {
 glyphname = eight;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -71246,7 +71579,7 @@ unicode = 56;
 },
 {
 glyphname = nine;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -71364,7 +71697,7 @@ unicode = 57;
 {
 category = Separator;
 glyphname = zerowidthnonjoiner;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -71402,7 +71735,7 @@ unicode = 8204;
 },
 {
 glyphname = period;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -71455,7 +71788,7 @@ unicode = 46;
 },
 {
 glyphname = comma;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -71516,7 +71849,7 @@ unicode = 44;
 },
 {
 glyphname = colon;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -71604,7 +71937,7 @@ unicode = 58;
 },
 {
 glyphname = semicolon;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -71700,7 +72033,7 @@ unicode = 59;
 },
 {
 glyphname = ellipsis;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -71823,7 +72156,7 @@ unicode = 8230;
 },
 {
 glyphname = exclam;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -71894,7 +72227,7 @@ unicode = 33;
 },
 {
 glyphname = question;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72005,7 +72338,7 @@ unicode = 63;
 },
 {
 glyphname = asterisk;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72070,7 +72403,7 @@ unicode = 42;
 },
 {
 glyphname = numbersign;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72173,7 +72506,7 @@ unicode = 35;
 },
 {
 glyphname = slash;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72210,7 +72543,7 @@ unicode = 47;
 },
 {
 glyphname = backslash;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72247,7 +72580,7 @@ unicode = 92;
 },
 {
 glyphname = hyphen;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72284,7 +72617,7 @@ unicode = 45;
 },
 {
 glyphname = uni00AD;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72311,7 +72644,7 @@ unicode = 173;
 },
 {
 glyphname = endash;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72348,7 +72681,7 @@ unicode = 8211;
 },
 {
 glyphname = emdash;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72385,7 +72718,7 @@ unicode = 8212;
 },
 {
 glyphname = underscore;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72422,7 +72755,7 @@ unicode = 95;
 },
 {
 glyphname = uni2010;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72449,7 +72782,7 @@ unicode = 8208;
 },
 {
 glyphname = parenleft;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72506,7 +72839,7 @@ unicode = 40;
 },
 {
 glyphname = parenright;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72563,7 +72896,7 @@ unicode = 41;
 },
 {
 glyphname = braceleft;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72664,7 +72997,7 @@ unicode = 123;
 },
 {
 glyphname = braceright;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72765,7 +73098,7 @@ unicode = 125;
 },
 {
 glyphname = bracketleft;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72822,7 +73155,7 @@ unicode = 91;
 },
 {
 glyphname = bracketright;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72879,7 +73212,7 @@ unicode = 93;
 },
 {
 glyphname = quotedblleft;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -72982,7 +73315,7 @@ unicode = 8220;
 },
 {
 glyphname = quotedblright;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73085,7 +73418,7 @@ unicode = 8221;
 },
 {
 glyphname = quoteleft;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73146,7 +73479,7 @@ unicode = 8216;
 },
 {
 glyphname = quoteright;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73207,7 +73540,7 @@ unicode = 8217;
 },
 {
 glyphname = quotedbl;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73264,7 +73597,7 @@ unicode = 34;
 },
 {
 glyphname = quotesingle;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73301,7 +73634,7 @@ unicode = 39;
 },
 {
 glyphname = bar;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73338,7 +73671,7 @@ unicode = 124;
 },
 {
 glyphname = rupeeIndian;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73439,7 +73772,7 @@ unicode = 8377;
 },
 {
 glyphname = plus;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73492,7 +73825,7 @@ unicode = 43;
 },
 {
 glyphname = minus;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73529,7 +73862,7 @@ unicode = 8722;
 },
 {
 glyphname = multiply;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73582,7 +73915,7 @@ unicode = 215;
 },
 {
 glyphname = divide;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73687,7 +74020,7 @@ unicode = 247;
 },
 {
 glyphname = equal;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73742,7 +74075,7 @@ unicode = 61;
 },
 {
 glyphname = greater;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73785,7 +74118,7 @@ unicode = 62;
 },
 {
 glyphname = less;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73828,7 +74161,7 @@ unicode = 60;
 },
 {
 glyphname = asciitilde;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73909,7 +74242,7 @@ unicode = 126;
 },
 {
 glyphname = asciicircum;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -73952,7 +74285,7 @@ unicode = 94;
 },
 {
 glyphname = percent;
-lastChange = "2020-12-02 21:56:54 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
@@ -74125,9 +74458,8 @@ unicode = 37;
 },
 {
 category = Mark;
-color = 10;
 glyphname = "rVocalicMatra-khoj";
-lastChange = "2022-08-30 09:01:01 +0000";
+lastChange = "2023-06-05 09:48:09 +0000";
 layers = (
 {
 anchors = (
@@ -74215,487 +74547,6 @@ width = 0;
 script = gujarati;
 subCategory = Nonspacing;
 unicode = 70209;
-},
-{
-color = 1;
-glyphname = "qa_iMatra-khoj";
-kernLeft = DA;
-kernRight = HI;
-lastChange = "2023-03-23 12:32:35 +0000";
-layers = (
-{
-anchors = (
-{
-name = bottom;
-pos = (715,-99);
-},
-{
-name = nukta;
-pos = (479,536);
-},
-{
-name = rakar;
-pos = (741,106);
-},
-{
-name = top;
-pos = (1164,892);
-}
-);
-layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
-shapes = (
-{
-closed = 1;
-nodes = (
-(751,-144,l),
-(776,-17,o),
-(822,192,o),
-(865,378,cs),
-(905,551,o),
-(930,678,o),
-(979,749,cs),
-(1009,792,o),
-(1046,814,o),
-(1101,814,cs),
-(1165,814,o),
-(1220,782,o),
-(1261,736,c),
-(1270,738,l),
-(1265,809,l),
-(1218,860,o),
-(1154,895,o),
-(1079,895,cs),
-(1005,895,o),
-(952,865,o),
-(913,814,cs),
-(854,737,o),
-(835,634,o),
-(799,462,cs),
-(723,104,l),
-(752,85,l),
-(732,139,o),
-(691,182,o),
-(598,182,cs),
-(594,182,o),
-(587,181,o),
-(584,181,c),
-(565,122,l),
-(581,128,o),
-(596,130,o),
-(611,130,cs),
-(666,130,o),
-(696,104,o),
-(696,43,cs),
-(696,10,o),
-(687,-37,o),
-(675,-99,c),
-(737,-146,l)
-);
-},
-{
-closed = 1;
-nodes = (
-(497,15,o),
-(670,214,o),
-(670,333,cs),
-(670,409,o),
-(606,509,o),
-(512,509,cs),
-(447,509,o),
-(400,453,o),
-(340,372,cs),
-(281,292,o),
-(244,237,o),
-(185,237,cs),
-(150,237,o),
-(125,256,o),
-(125,297,cs),
-(125,352,o),
-(169,405,o),
-(227,405,cs),
-(275,405,o),
-(289,347,o),
-(291,284,c),
-(333,316,l),
-(328,410,o),
-(283,486,o),
-(194,486,cs),
-(110,486,o),
-(45,415,o),
-(45,338,cs),
-(45,252,o),
-(128,166,o),
-(221,166,cs),
-(299,166,o),
-(344,226,o),
-(411,313,cs),
-(465,383,o),
-(503,433,o),
-(550,433,cs),
-(585,433,o),
-(610,405,o),
-(610,368,cs),
-(610,306,o),
-(542,234,o),
-(484,193,c),
-(412,170,o),
-(350,136,o),
-(350,95,cs),
-(350,60,o),
-(388,15,o),
-(423,15,cs)
-);
-}
-);
-width = 980;
-},
-{
-anchors = (
-{
-name = bottom;
-pos = (769,-128);
-},
-{
-name = nukta;
-pos = (508,540);
-},
-{
-name = rakar;
-pos = (799,106);
-},
-{
-name = top;
-pos = (1256,918);
-}
-);
-layerId = "A430B39A-257A-41FC-BEA9-652C696FFEF7";
-shapes = (
-{
-closed = 1;
-nodes = (
-(823,-164,l),
-(856,1,o),
-(900,205,o),
-(937,376,cs),
-(970,529,o),
-(994,623,o),
-(1020,683,cs),
-(1050,753,o),
-(1100,801,o),
-(1184,801,cs),
-(1245,801,o),
-(1309,771,o),
-(1351,727,c),
-(1364,732,l),
-(1348,829,l),
-(1283,888,o),
-(1215,918,o),
-(1140,918,cs),
-(1041,918,o),
-(969,871,o),
-(922,782,cs),
-(884,710,o),
-(860,608,o),
-(833,477,cs),
-(758,119,l),
-(796,125,l),
-(761,169,o),
-(717,187,o),
-(664,187,cs),
-(650,187,o),
-(635,185,o),
-(620,181,c),
-(607,98,l),
-(621,107,o),
-(641,113,o),
-(661,113,cs),
-(694,113,o),
-(729,95,o),
-(729,43,cs),
-(729,10,o),
-(721,-39,o),
-(708,-108,c),
-(790,-169,l)
-);
-},
-{
-closed = 1;
-nodes = (
-(545,-16,o),
-(722,182,o),
-(722,318,cs),
-(722,422,o),
-(637,528,o),
-(536,528,cs),
-(464,528,o),
-(415,490,o),
-(342,386,cs),
-(270,283,o),
-(236,244,o),
-(186,244,cs),
-(158,244,o),
-(142,262,o),
-(142,291,cs),
-(142,344,o),
-(191,392,o),
-(238,392,cs),
-(279,392,o),
-(296,355,o),
-(304,293,c),
-(360,338,l),
-(346,439,o),
-(300,511,o),
-(202,511,cs),
-(108,511,o),
-(30,435,o),
-(30,341,cs),
-(30,240,o),
-(127,145,o),
-(234,145,cs),
-(324,145,o),
-(383,214,o),
-(449,300,cs),
-(519,391,o),
-(555,418,o),
-(585,418,cs),
-(615,418,o),
-(631,394,o),
-(630,363,cs),
-(628,314,o),
-(570,240,o),
-(516,202,c),
-(444,179,o),
-(361,140,o),
-(361,84,cs),
-(361,37,o),
-(406,-16,o),
-(453,-16,cs)
-);
-}
-);
-width = 1057;
-}
-);
-metricLeft = "ka-khoj.alt";
-metricRight = "ka_iMatra-khoj";
-script = khoj;
-},
-{
-color = 1;
-glyphname = "qa_uMatra-khoj";
-kernLeft = KU;
-kernRight = KA;
-lastChange = "2023-03-23 12:33:35 +0000";
-layers = (
-{
-anchors = (
-{
-name = bottom;
-pos = (520,-179);
-},
-{
-name = nukta;
-pos = (454,536);
-},
-{
-name = top;
-pos = (659,516);
-}
-);
-layerId = "0717401B-DDB5-4983-85F2-A81AFE530D5E";
-shapes = (
-{
-closed = 1;
-nodes = (
-(520,15,o),
-(693,214,o),
-(693,333,cs),
-(693,409,o),
-(629,509,o),
-(535,509,cs),
-(470,509,o),
-(423,453,o),
-(363,372,cs),
-(304,292,o),
-(267,237,o),
-(208,237,cs),
-(173,237,o),
-(148,256,o),
-(148,297,cs),
-(148,352,o),
-(192,405,o),
-(250,405,cs),
-(298,405,o),
-(314,347,o),
-(317,284,c),
-(356,316,l),
-(351,410,o),
-(306,486,o),
-(217,486,cs),
-(133,486,o),
-(68,415,o),
-(68,338,cs),
-(68,252,o),
-(151,166,o),
-(244,166,cs),
-(322,166,o),
-(367,226,o),
-(434,313,cs),
-(488,383,o),
-(526,433,o),
-(573,433,cs),
-(608,433,o),
-(633,405,o),
-(633,368,cs),
-(633,306,o),
-(565,234,o),
-(507,193,c),
-(435,170,o),
-(373,136,o),
-(373,95,cs),
-(373,60,o),
-(411,15,o),
-(446,15,cs)
-);
-},
-{
-closed = 1;
-nodes = (
-(670,-191,o),
-(793,-111,o),
-(793,17,cs),
-(793,139,o),
-(681,201,o),
-(593,201,c),
-(580,129,l),
-(596,136,o),
-(612,140,o),
-(628,140,cs),
-(678,140,o),
-(720,110,o),
-(720,50,cs),
-(720,-45,o),
-(622,-108,o),
-(490,-108,cs),
-(327,-108,o),
-(169,-5,o),
-(60,146,c),
-(52,142,l),
-(45,86,l),
-(156,-76,o),
-(340,-191,o),
-(521,-191,cs)
-);
-}
-);
-width = 823;
-},
-{
-anchors = (
-{
-name = bottom;
-pos = (535,-189);
-},
-{
-name = nukta;
-pos = (469,536);
-},
-{
-name = top;
-pos = (674,516);
-}
-);
-layerId = "A430B39A-257A-41FC-BEA9-652C696FFEF7";
-shapes = (
-{
-closed = 1;
-nodes = (
-(559,-16,o),
-(736,182,o),
-(736,318,cs),
-(736,422,o),
-(651,528,o),
-(550,528,cs),
-(478,528,o),
-(429,490,o),
-(356,386,cs),
-(284,283,o),
-(250,244,o),
-(200,244,cs),
-(172,244,o),
-(156,262,o),
-(156,291,cs),
-(156,344,o),
-(205,392,o),
-(252,392,cs),
-(293,392,o),
-(310,355,o),
-(318,293,c),
-(374,338,l),
-(360,439,o),
-(314,511,o),
-(216,511,cs),
-(122,511,o),
-(44,435,o),
-(44,341,cs),
-(44,240,o),
-(141,145,o),
-(248,145,cs),
-(338,145,o),
-(397,214,o),
-(463,300,cs),
-(533,391,o),
-(569,418,o),
-(599,418,cs),
-(629,418,o),
-(645,394,o),
-(644,363,cs),
-(642,314,o),
-(584,240,o),
-(530,202,c),
-(458,179,o),
-(375,140,o),
-(375,84,cs),
-(375,37,o),
-(420,-16,o),
-(467,-16,cs)
-);
-},
-{
-closed = 1;
-nodes = (
-(737,-223,o),
-(843,-127,o),
-(843,3,cs),
-(843,122,o),
-(736,207,o),
-(605,209,c),
-(594,71,l),
-(619,93,o),
-(646,105,o),
-(680,105,cs),
-(713,105,o),
-(736,86,o),
-(736,47,cs),
-(736,-33,o),
-(643,-98,o),
-(505,-98,cs),
-(339,-98,o),
-(187,-16,o),
-(58,155,c),
-(44,153,l),
-(30,72,l),
-(154,-110,o),
-(340,-223,o),
-(549,-223,cs)
-);
-}
-);
-width = 858;
-}
-);
-metricRight = "ka_uMatra-khoj";
-script = khoj;
 }
 );
 instances = (
@@ -75911,7 +75762,7 @@ value = "Noto is a trademark of Google LLC.";
 },
 {
 key = versionString;
-value = "Version 2.004";
+value = "Version 2.003";
 }
 );
 settings = {
@@ -75932,5 +75783,5 @@ name = vStem0;
 );
 unitsPerEm = 1000;
 versionMajor = 2;
-versionMinor = 4;
+versionMinor = 3;
 }


### PR DESCRIPTION
In NotoSansKhojki
– Added glyphs kj_Ishort(U+11240),  kj_QA (U+1123F)
– Added glyphs QA.alt, QU, QRA (based on Ka.alt, KU, KRA respectively)
– Added anchors and gsub codes for glyphs above
– Edited codes for KRA,MRA,SRA,BHRA and QRA in ccmp features under VowelConjuncts lookup. (Removed uni2000D as rakar forms were not getting substituted otherwise.)

In NotoSerifKhojki
– Added glyphs kj_Ishort(U+11240)
– Checked/fixed anchors/side bearings for qa-khoj, qa_iMatra-khoj, qa_iiMatra-khoj, qa_uMatra-khoj, q_ra_uMatra-khoj, kj_Ishort
– Added gsub codes for glyphs above